### PR TITLE
Use std::ios:off_type(0) together with std::ios::beg in seekg

### DIFF
--- a/Graph/AdjIO.h
+++ b/Graph/AdjIO.h
@@ -130,7 +130,7 @@ std::istream& read_adj(std::istream& in, ContigGraph<Graph>& g,
 	if (adjFormat || faiFormat) {
 		assert(num_vertices(g) == 0);
 		in.clear();
-		in.seekg(std::ios_base::beg);
+		in.seekg(std::ios::off_type(0), std::ios_base::beg);
 		assert(in);
 		for (std::string uname; in >> uname;) {
 			vertex_property_type vp;
@@ -155,7 +155,7 @@ std::istream& read_adj(std::istream& in, ContigGraph<Graph>& g,
 
 	// Read the edges.
 	in.clear();
-	in.seekg(std::ios_base::beg);
+	in.seekg(std::ios::off_type(0), std::ios_base::beg);
 	assert(in);
 	for (std::string name; in >> name;) {
 		if (adjFormat)


### PR DESCRIPTION
While testing non-g++ ABySS, we found reading .adj file was finished with incomplete
number of edges due to the parameters set originally for seekg. Fix that so .adj file read works.   
