### PR TITLE
AdjIO: Bug fix for non-GCC compilers

### DIFF
--- a/Graph/AdjIO.h
+++ b/Graph/AdjIO.h
@@ -169,7 +169,8 @@ std::istream& read_adj(std::istream& in, ContigGraph<Graph>& g,
 			if (!adjFormat) {
 				readDistEdges(ss, g, u ^ sense, betterEP);
 			} else
-			for (std::string vname; ss >> vname >> std::ws;) {
+			for (std::string vname; ss >> vname;) {
+				ss >> std::ws;
 				vertex_descriptor v = find_vertex(vname, g);
 				assert(!edge(u ^ sense, v ^ sense, g).second);
 				if (ss.peek() == '[') {


### PR DESCRIPTION
On some compilers std::ws sets the failbit if the stream already at
the end. (The Standard does not state anything about the behavior)

Move the operation in the loop below so the program parses the file
correctly.
