### PR TITLE
Add explicit version checking to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -22,7 +22,7 @@ AUMAKE_VERSION=`automake --version 2>/dev/null | awk '/^automake/ { print $4 }'`
 #       compare_version 1.2.10  1.3.0
 #       # => -1
 #
-function compare_version() {
+compare_version () {
     echo $1 $2 | awk '
     { split($1, a, ".");
       split($2, b, ".");


### PR DESCRIPTION
```
Added a bash script to autogen.sh which ensures that recent version of
automake and autoconf are installed.
```

I adapted this from a script I had for version dependency checking in a different project, if you guys are interested. It makes things a little clearer as to what the problem is.

I tested it with autotools missing, autotools out of date, and everything peachy.
