### PR TITLE
Include <string> for std::hash if FCC is used.

### DIFF
--- a/Common/Hash.h
+++ b/Common/Hash.h
@@ -4,7 +4,11 @@
 #include "config.h"
 
 #if HAVE_STD_HASH
+#ifdef __FUJITSU
+# include <string>
+#else
 # include <functional>
+#endif
 using std::hash;
 # define NAMESPACE_STD_HASH_BEGIN namespace std {
 # define NAMESPACE_STD_HASH_END }

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,12 @@ AC_LANG_PUSH([C++])
 AC_CHECK_TYPE([std::hash<int>],
 	AC_DEFINE(HAVE_STD_HASH, [1],
 		[Define if the system provides std::hash]),
-	[], [#include <functional>])
+	[], [
+#ifdef __FUJITSU
+#include <string>
+#else
+#include <functional>
+#endif])
 AC_CHECK_TYPE([std::tr1::hash<int>],
 	AC_DEFINE(HAVE_STD_TR1_HASH, [1],
 		[Define if the system provides std::tr1::hash]),


### PR DESCRIPTION
In FCC, std::hash is defined in header <string>. Use predefined macro __FUJITSU to change the header to include. Please note that the standard does not state anything about the header layouts, so they took
the liberty of implementing that their own way.
@sjackman et al. please review the patch for the inclusion.

Thanks!
