### PR TITLE
use more portable /usr/bin/env perl for scripts

### DIFF
--- a/bin/abyss-adjtodot.pl
+++ b/bin/abyss-adjtodot.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Convert an ABySS adjacency file to GraphViz dot format.
 # Written by Shaun Jackman <sjackman@bcgsc.ca>.
 use strict;

--- a/bin/abyss-cstont
+++ b/bin/abyss-cstont
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Convert colour-space FASTA sequences to nucleotide FASTA sequences.
 # Written by Shaun Jackman <sjackman@bcgsc.ca>.
 # Usage: cstofasta data.csfa >data.fa

--- a/bin/abyss-fac.pl
+++ b/bin/abyss-fac.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # abyss-fac (FASTA count)
 # Calculate assembly contiguity statistics, such as N50.
 # Written by Shaun Jackman <sjackman@bcgsc.ca>.

--- a/bin/abyss-fatoagp
+++ b/bin/abyss-fatoagp
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Convert a FASTA file of scaffolds to a FASTA file of contigs and an
 # AGP file.
 # Written by Shaun Jackman <sjackman@bcgsc.ca>.

--- a/bin/abyss-joindist
+++ b/bin/abyss-joindist
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Join multiple ABySS distance estimate files.
 # Written by Shaun Jackman <sjackman@bcgsc.ca>.
 use strict;

--- a/bin/abyss-samtoafg
+++ b/bin/abyss-samtoafg
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use Getopt::Long;
 use Pod::Usage;


### PR DESCRIPTION
This is useful, e.g. if your perl is not installed in /usr/bin or you want to give a specific perl precendence over the one installed in /usr/bin.