### PR TITLE
add in abyss-sealer to abyss-pe run

### DIFF
--- a/bin/abyss-pe
+++ b/bin/abyss-pe
@@ -357,7 +357,7 @@ ifneq ($(in),)
 default: contigs contigs-graph
 endif
 ifneq ($(mp),)
-default: scaffolds scaffolds-graph
+default: scaffolds scaffolds-graph seal-scaffolds
 ifneq ($(long),)
 default: long-scaffs long-scaffs-graph
 endif
@@ -644,7 +644,7 @@ endif
 sealer_ks?=-k90 -k80 -k70 -k60 -k50 -k40 -k30
 
 %-8_scaffold.fa: %-8.fa
-	abyss-sealer -v -j$j --print-flanks -o$*-8 -S$< $(sealer_ks) $(SEALER_OPTIONS) $(in) $(se)
+	abyss-sealer -v -j$j --print-flanks -o $*-8 -S $< $(sealer_ks) $(SEALER_OPTIONS) $(in) $(se)
 
 %-scaffolds-sealed.fa: %-8_scaffold.fa
 	ln -s $< $@


### PR DESCRIPTION
not sure if leaving out sealer in the 'normal' abyss-pe is intended or an oversight.. Pull request adds this in if it's a mistake..
