### PR TITLE
Fix BUGs of abyss-tofastq 

### DIFF
--- a/DataLayer/FastaReader.h
+++ b/DataLayer/FastaReader.h
@@ -168,11 +168,14 @@ struct FastqRecord : FastaRecord
 {
 	/** Quality */
 	std::string qual;
-
-	FastqRecord() { }
+	char default_qual;
+	FastqRecord()
+		:default_qual('2')
+	{
+	}
 	FastqRecord(const std::string& id, const std::string& comment,
-			const Sequence& seq, const std::string& qual)
-		: FastaRecord(id, comment, seq), qual(qual)
+			const Sequence& seq, const std::string& qual, const char _default_qual = '2')
+		: FastaRecord(id, comment, seq), qual(qual), default_qual(_default_qual)
 	{
 		assert(seq.length() == qual.length());
 	}
@@ -184,10 +187,11 @@ struct FastqRecord : FastaRecord
 	}
 
 	friend std::ostream& operator <<(std::ostream& out,
-			const FastqRecord& o)
+			FastqRecord& o)
 	{
 		if (o.qual.empty())
-			return out << static_cast<const FastaRecord&>(o);
+			o.qual = std::string(o.seq.length(), o.default_qual);
+//			return out << static_cast<const FastaRecord&>(o);
 		out << '@' << o.id;
 		if (!o.comment.empty())
 			out << ' ' << o.comment;

--- a/DataLayer/abyss-tofastq.cc
+++ b/DataLayer/abyss-tofastq.cc
@@ -66,8 +66,8 @@ static const char shortopts[] = "iq:v";
 enum { OPT_HELP = 1, OPT_VERSION };
 
 static const struct option longopts[] = {
-	{ "cat",              no_argument, &opt::interleave, 0 },
-	{ "interleave",       no_argument, &opt::interleave, 1 },
+	{ "cat",              no_argument, &opt::interleave, 1 },
+	{ "interleave",       no_argument, &opt::interleave, 0 },
 	{ "fasta",            no_argument, &opt::toFASTQ, 0 },
 	{ "fastq",            no_argument, &opt::toFASTQ, 1 },
 	{ "chastity",         no_argument, &opt::chastityFilter, 1 },


### PR DESCRIPTION
Fix BUG:abyss-tofastq cannot convert .fa to .fastq (EX. Use Dida)
Fix BUG:make --cat become default rather than -i (help info said --cat should be defult)
