### PR TITLE
Be specific about licensing terms in COPYRIGHT

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -22,7 +22,7 @@ License: GPL-NC-3+
  .
  Debian may redistribute this software package.
 
-Files: autogen.sh bin/* ChangeLog circle.yml CITATION.bib CITATION.md configure.ac COPYRIGHT doc/* Dockerfile doxygen.conf IntegrationTest/* lib/* LICENSE m4/* Makefile.am Misc/* README.md
+Files: autogen.sh bin/* ChangeLog circle.yml CITATION.bib CITATION.md configure.ac COPYRIGHT doc/* Dockerfile doxygen.conf IntegrationTest/* LICENSE m4/* Makefile.am Misc/* README.md
 Copyright: Copyright 2014 Canada's Michael Smith Genome Sciences Centre
 License: GPL-NC-3+
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -22,7 +22,7 @@ License: GPL-NC-3+
  .
  Debian may redistribute this software package.
 
-Files: *
+Files: autogen.sh bin/* ChangeLog circle.yml CITATION.bib CITATION.md configure.ac COPYRIGHT doc/* Dockerfile doxygen.conf IntegrationTest/* lib/* LICENSE m4/* Makefile.am Misc/* README.md
 Copyright: Copyright 2014 Canada's Michael Smith Genome Sciences Centre
 License: GPL-NC-3+
 


### PR DESCRIPTION
This pull request is in response to a Twitter tempe^H^H^H^H^Hexchange which seemed overblown.  The most rational course of action would appear to be explicit licensing of components as currently stands in COPYRIGHT, with implicit licensing of additional components "compromised" by GPLv3.  However, the GPLv3-licensed components, along with sections 1, 7, and 10 of the GPLv3, render the point moot; either the entire project is GPLv3, or it needs to be relicensed and clean-roomed. 

It turns out that by specifically GPLv3 licensing (e.g.) `Common/*`, any code that happens to directly 
`#include` code from `Common/` is "infected" by the GPLv3, sections 7 and 10, which specifically disallow further restrictions save for very narrow exceptions (see https://www.gnu.org/licenses/gpl-faq.en.html#NoMilitary, which is of course not binding *per se*).  `Common/*` infects `Graph/*`, `Bloom/*`, and most branches of the code either directly or indirectly in this fashion, thus they are implicitly licensed under GPLv3 terms themselves (at least in their current form).

I can find nothing to *directly, explicitly* suggest GPLv3 "infection" of
```
autogen.sh bin ChangeLog circle.yml CITATION.bib CITATION.md configure.ac 
COPYRIGHT doc Dockerfile doxygen.conf IntegrationTest lib LICENSE m4 
Makefile.am Misc README.md
```
although section 1 of the GPLv3 would lump most of these in with "build scripts, etc".  It would be a good idea to spell out which items are explicitly GPLv3, LGPLv2.1, BSD 3-clause, and/or Expat licensed, which are explicitly sublicensed under GPLv3 for non-commercial use, and by omission, those implicitly infected by GPLv3 licensing at compile time in the current configuration.  At the very least this would clarify what was not already GPLv3 or otherwise OSS licensed at this time.

I am not a lawyer, nor am I licensed to practice law in any US state or Canadian province.  The only settled legal precedents for GPL "infection" occur in Belgian and German case law.  A Canadian judge might well rule differently.  Nonetheless, it cannot hurt to be explicit about licensing terms.  Furthermore, since nearly all of the code under GPLv3 derives from Shaun Jackman or other BCCA/BCGSC employees, there is absolutely no reason that it cannot be re-licensed *en bloc* to fall under a noncommercial license (all contributors must agree to a license change, but all contributors have presumably assigned rights to BCCA/BCGSC as a condition of employment).

This PR seeks solely to disambiguate licensing cross-contamination as it currently exists in ABySS.