### PR TITLE
fix OSX/clang linking issue due to `&std::string::length`

### DIFF
--- a/MergePaths/PathConsensus.cpp
+++ b/MergePaths/PathConsensus.cpp
@@ -533,6 +533,13 @@ static ContigPath alignPair(const Graph& g,
 	return path;
 }
 
+template <typename Seq>
+struct GetLength {
+    size_t operator()(const Seq& sequence) {
+        return sequence.length();
+    }
+};
+
 /* Resolve ambiguous region using multiple alignment of all paths in
  * `solutions'.
  */
@@ -615,7 +622,7 @@ static ContigPath alignMulti(const Graph& g,
 
 	vector<unsigned> lengths(amb_seqs.size());
 	transform(amb_seqs.begin(), amb_seqs.end(), lengths.begin(),
-			mem_fun_ref(&string::length));
+			GetLength<Sequence>());
 	unsigned minLength = *min_element(lengths.begin(), lengths.end());
 	unsigned maxLength = *max_element(lengths.begin(), lengths.end());
 	float lengthRatio = (float)minLength / maxLength;


### PR DESCRIPTION
Compiling/linking on OSX with `clang` and `libc++` fails due to using a pointer to member function `std::string::length` which apparently isn't exported for `libc++`, see:
http://lists.llvm.org/pipermail/cfe-dev/2013-March/028407.html

With C++11 and onward a lambda function could be used. Since this project doesn't appear use C++11, a functor is used instead.