### PR TITLE
Kmer.cpp: Fix unaligned memory access in big-endian load and storedReverse.

### DIFF
--- a/Common/Kmer.cpp
+++ b/Common/Kmer.cpp
@@ -188,9 +188,10 @@ static Seq load(const uint8_t *src)
 	Seq seq;
 #if MAX_KMER > 96
 # if WORDS_BIGENDIAN
-	const uint64_t *s = reinterpret_cast<const uint64_t*>(src);
-	uint64_t *d = reinterpret_cast<uint64_t*>(&seq + 1);
-	copy(s, s + SEQ_WORDS, reverse_iterator<uint64_t*>(d));
+	size_t s[Kmer::NUM_BYTES/sizeof(size_t)];
+	memcpy(s, src, Kmer::NUM_BYTES);
+	size_t *d = reinterpret_cast<size_t*>(&seq + 1);
+	copy(s, s + Kmer::NUM_BYTES/sizeof(size_t), reverse_iterator<size_t*>(d));
 # else
 	uint8_t *d = reinterpret_cast<uint8_t*>(&seq);
 	memcpy(d, src, sizeof seq);
@@ -234,10 +235,11 @@ static void storeReverse(uint8_t *dest, const Seq seq)
 {
 #if MAX_KMER > 96
 # if WORDS_BIGENDIAN
-	const uint64_t *s = reinterpret_cast<const uint64_t*>(&seq);
-	uint64_t *d = reinterpret_cast<uint64_t*>(dest);
-	copy(s, s + SEQ_WORDS,
-			reverse_iterator<uint64_t*>(d + SEQ_WORDS));
+	const size_t *s = reinterpret_cast<const size_t*>(&seq);
+	size_t d[Kmer::NUM_BYTES/sizeof(size_t)];
+	copy(s, s + Kmer::NUM_BYTES/sizeof(size_t),
+			reverse_iterator<size_t*>(d +  Kmer::NUM_BYTES/sizeof(size_t)));
+	memcpy(dest, d, Kmer::NUM_BYTES);
 	reverse(dest, dest + Kmer::NUM_BYTES);
 # else
 	memcpy(dest, &seq, Kmer::NUM_BYTES);

--- a/Common/Kmer.cpp
+++ b/Common/Kmer.cpp
@@ -188,10 +188,9 @@ static Seq load(const uint8_t *src)
 	Seq seq;
 #if MAX_KMER > 96
 # if WORDS_BIGENDIAN
-	size_t buf[Kmer::NUM_BYTES];
-	memcpy(buf, src, Kmer::NUM_BYTES);
-	size_t *d = reinterpret_cast<size_t*>(&seq + 1);
-	copy(buf, buf + Kmer::NUM_BYTES/sizeof(size_t), reverse_iterator<size_t*>(d));
+	const uint64_t *s = reinterpret_cast<const uint64_t*>(src);
+	uint64_t *d = reinterpret_cast<uint64_t*>(&seq + 1);
+	copy(s, s + SEQ_WORDS, reverse_iterator<uint64_t*>(d));
 # else
 	uint8_t *d = reinterpret_cast<uint8_t*>(&seq);
 	memcpy(d, src, sizeof seq);
@@ -235,11 +234,10 @@ static void storeReverse(uint8_t *dest, const Seq seq)
 {
 #if MAX_KMER > 96
 # if WORDS_BIGENDIAN
-	const size_t *s = reinterpret_cast<const size_t*>(&seq);
-	size_t d[Kmer::NUM_BYTES];
-	copy(s, s + Kmer::NUM_BYTES/sizeof(size_t),
-			reverse_iterator<size_t*>(d +  Kmer::NUM_BYTES/sizeof(size_t)));
-	memcpy(dest, d, Kmer::NUM_BYTES);
+	const uint64_t *s = reinterpret_cast<const uint64_t*>(&seq);
+	uint64_t *d = reinterpret_cast<uint64_t*>(dest);
+	copy(s, s + SEQ_WORDS,
+			reverse_iterator<uint64_t*>(d + SEQ_WORDS));
 	reverse(dest, dest + Kmer::NUM_BYTES);
 # else
 	memcpy(dest, &seq, Kmer::NUM_BYTES);

--- a/Common/Kmer.cpp
+++ b/Common/Kmer.cpp
@@ -188,9 +188,10 @@ static Seq load(const uint8_t *src)
 	Seq seq;
 #if MAX_KMER > 96
 # if WORDS_BIGENDIAN
-	const uint64_t *s = reinterpret_cast<const uint64_t*>(src);
-	uint64_t *d = reinterpret_cast<uint64_t*>(&seq + 1);
-	copy(s, s + SEQ_WORDS, reverse_iterator<uint64_t*>(d));
+	size_t buf[Kmer::NUM_BYTES];
+	memcpy(buf, src, Kmer::NUM_BYTES);
+	size_t *d = reinterpret_cast<size_t*>(&seq + 1);
+	copy(buf, buf + Kmer::NUM_BYTES/sizeof(size_t), reverse_iterator<size_t*>(d));
 # else
 	uint8_t *d = reinterpret_cast<uint8_t*>(&seq);
 	memcpy(d, src, sizeof seq);
@@ -234,10 +235,11 @@ static void storeReverse(uint8_t *dest, const Seq seq)
 {
 #if MAX_KMER > 96
 # if WORDS_BIGENDIAN
-	const uint64_t *s = reinterpret_cast<const uint64_t*>(&seq);
-	uint64_t *d = reinterpret_cast<uint64_t*>(dest);
-	copy(s, s + SEQ_WORDS,
-			reverse_iterator<uint64_t*>(d + SEQ_WORDS));
+	const size_t *s = reinterpret_cast<const size_t*>(&seq);
+	size_t d[Kmer::NUM_BYTES];
+	copy(s, s + Kmer::NUM_BYTES/sizeof(size_t),
+			reverse_iterator<size_t*>(d +  Kmer::NUM_BYTES/sizeof(size_t)));
+	memcpy(dest, d, Kmer::NUM_BYTES);
 	reverse(dest, dest + Kmer::NUM_BYTES);
 # else
 	memcpy(dest, &seq, Kmer::NUM_BYTES);


### PR DESCRIPTION
This pull request replaces and builds on the big endian fix here: #139 and fixes a test failure on the sparc64 architecture. The issue with the #139 patch is that it casts a uint8_t* to a size_t*. When casting between pointer types in c or c++ we have to make sure that cast value has the correct alignment for the new type. Alignment here meaning that the pointer value is an integer multiple of the necessary alignment. The necessary alignment is architecture dependent, for example, on the sparc64 architecture a size_t* value must be an integer multiple of 8. If the pointer value doesn't have the proper alignment for the new type, the result is undefined behavior:

C11 Appendix J.2:

    1 The behavior is undefined in the following circumstances:

    ....

    Conversion between two pointer types produces a result that is incorrectly aligned (6.3.2.3).

To fix this I added a stack allocated buffer with the size_t type and memcpy the value to it. The compiler ensures that the buffer has the proper alignment.

This patch shouldn't have any effect on little-endian architectures like x86 and amd64 because the preprocessor will eliminate it before compilation.

Thanks!

UPDATE: Based on some feedback from the debian-sparc mailing list I changed a variable name and corrected the buffer sizes by dividing by sizeof(size_t).