### PR TITLE
Histogram: Remove unused std::swap

### DIFF
--- a/Common/Histogram.h
+++ b/Common/Histogram.h
@@ -310,11 +310,6 @@ class Histogram
 	Map m_map;
 };
 
-namespace std {
-	template<>
-	inline void swap(Histogram&, Histogram&) { assert(false); }
-}
-
 /** Print assembly contiguity statistics header. */
 static inline std::ostream& printContiguityStatsHeader(
 		std::ostream& out,


### PR DESCRIPTION
Fix
```
./Histogram.h:315:14: error: 'swap<Histogram>' is missing exception specification
'noexcept(__and_<is_nothrow_move_constructible<Histogram>, is_nothrow_move_assignable<Histogram> >::value)'
```
See https://circleci.com/gh/bcgsc/abyss/115