### PR TITLE
Add kseq.h lib to FastaReader

### DIFF
--- a/ABYSS/Makefile.am
+++ b/ABYSS/Makefile.am
@@ -7,6 +7,6 @@ ABYSS_LDADD = \
 	$(SQLITE_LIBS) \
 	$(top_builddir)/Assembly/libassembly.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 ABYSS_SOURCES = abyss.cc

--- a/AdjList/Makefile.am
+++ b/AdjList/Makefile.am
@@ -10,7 +10,7 @@ endif
 
 AdjList_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 if PAIRED_DBG
 AdjList_LDADD += \
@@ -19,7 +19,7 @@ endif
 
 AdjList_LDADD += \
 	$(top_builddir)/DataBase/libdb.a \
-	$(SQLITE_LIBS)
+	$(SQLITE_LIBS) -lz
 
 AdjList_SOURCES = \
 	AdjList.cpp

--- a/Align/Makefile.am
+++ b/Align/Makefile.am
@@ -18,7 +18,7 @@ abyss_align_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 abyss_align_LDADD = $(builddir)/libalign.a \
 	$(top_builddir)/dialign/libdialign.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_align_SOURCES = align.cc
 
@@ -31,6 +31,6 @@ abyss_mergepairs_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 abyss_mergepairs_LDADD = $(builddir)/libalign.a \
 	$(top_builddir)/dialign/libdialign.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_mergepairs_SOURCES = mergepairs.cc

--- a/Bloom/Makefile.am
+++ b/Bloom/Makefile.am
@@ -9,7 +9,7 @@ abyss_bloom_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 abyss_bloom_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_bloom_SOURCES = bloom.cc \
 	Bloom.h \

--- a/BloomDBG/Makefile.am
+++ b/BloomDBG/Makefile.am
@@ -8,7 +8,7 @@ abyss_bloom_dbg_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 
 abyss_bloom_dbg_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_bloom_dbg_SOURCES = \
 	AssemblyCounters.h \

--- a/Consensus/Makefile.am
+++ b/Consensus/Makefile.am
@@ -6,7 +6,7 @@ Consensus_CPPFLAGS = -I$(top_srcdir) \
 
 Consensus_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 Consensus_SOURCES = \
 	Consensus.cpp

--- a/DAssembler/Makefile.am
+++ b/DAssembler/Makefile.am
@@ -6,7 +6,7 @@ DAssembler_CPPFLAGS = -I$(top_srcdir) \
 
 DAssembler_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 DAssembler_SOURCES = DAssembler.cpp \
 	RotatedRead.cpp RotatedRead.h \

--- a/DataLayer/FastaReader.cpp
+++ b/DataLayer/FastaReader.cpp
@@ -10,6 +10,12 @@
 #include <sstream>
 #include <vector>
 
+extern "C" {
+#include "kseq.h"
+}
+#include <zlib.h>
+KSEQ_INIT(gzFile, gzread)
+
 using namespace std;
 
 namespace opt {
@@ -44,18 +50,72 @@ ostream& FastaReader::die()
 	return cerr << m_path << ':' << m_line << ": error: ";
 }
 
+static bool is_file_fasta(string path) {
+	return endsWith(path, ".fasta") ||
+		   endsWith(path, ".fasta.gz") ||
+		   endsWith(path, ".fa") ||
+		   endsWith(path, ".fa.gz");
+}
+
+static bool is_file_fastq(string path) {
+	return endsWith(path, ".fastq") ||
+		   endsWith(path, ".fastq.gz") ||
+		   endsWith(path, ".fq") ||
+		   endsWith(path, ".fq.gz");
+}
+
 FastaReader::FastaReader(const char* path, int flags, int len)
-	: m_path(path), m_fin(path),
-	m_in(strcmp(path, "-") == 0 ? cin : m_fin),
+	: m_path(path),
 	m_flags(flags), m_line(0), m_unchaste(0),
 	m_end(numeric_limits<streamsize>::max()),
 	m_maxLength(len)
 {
-	if (strcmp(path, "-") != 0)
-		assert_good(m_fin, path);
-	if (m_in.peek() == EOF)
-		cerr << m_path << ':' << m_line << ": warning: "
-			"file is empty\n";
+	if (is_file_fasta(path) || is_file_fastq(path)) {
+		if (is_file_fastq(path)) {
+			q = true;
+		}
+	    is_fasta = true;
+		m_file = gzopen(path, "r");
+		m_file_state = 0;
+		seq_data = kseq_init((gzFile)m_file);
+	} else {
+		m_fin = new ifstream(path);
+		m_in = (strcmp(path, "-") == 0 ? &cin : m_fin);
+
+		if (strcmp(path, "-") != 0)
+			assert_good(*m_fin, path);
+		if (m_in->peek() == EOF)
+			cerr << m_path << ':' << m_line << ": warning: "
+				"file is empty\n";
+	}
+}
+
+FastaReader::~FastaReader()
+{
+	if (is_fasta) {
+		kseq_destroy((kseq_t*)seq_data);
+		gzclose((gzFile)m_file);
+	} else {
+		if (!m_in->eof()) {
+			std::string line;
+			getline(line);
+			die() << "expected end-of-file near\n"
+				<< line << '\n';
+			exit(EXIT_FAILURE);
+		}
+
+		delete m_fin;
+	}
+}
+
+int gzpeek(gzFile f)
+{
+    int c;
+
+    c = gzgetc(f);
+    gzungetc(c, f);
+
+    return c;
 }
 
 /** Split the fasta file into nsections and seek to the start
@@ -67,31 +127,64 @@ void FastaReader::split(unsigned section, unsigned nsections)
 	assert(strcmp(m_path, "-") != 0);
 	if (nsections == 1)
 		return;
-	// Move the get pointer to the first entry in this section and
-	// update the m_end if there is more than one section.
-	m_in.seekg(0, ios::end);
-	streampos length = m_in.tellg();
-	assert(length > 0);
-	streampos start = length * (section - 1) / nsections;
-	streampos end = length * section / nsections;
-	assert(end > 0);
-	if (end < length) {
-		m_in.seekg(end);
-		if (m_in.peek() == '>')
-			end += 1;
+
+	if (is_fasta) {
+		// Move the get pointer to the first entry in this section and
+		// update the m_end if there is more than one section.
+		gzseek((gzFile)m_file, 0L, SEEK_END);
+		long length = gztell((gzFile)m_file);
+		assert(length > 0);
+		long start = length * (section - 1) / nsections;
+		long end = length * section / nsections;
+		assert(end > 0);
+		if (end < length) {
+			gzseek((gzFile)m_file, 0, end);
+			if (gzpeek((gzFile)m_file) == '>')
+				end += 1;
+		}
+		m_file_end = end;
+		gzseek((gzFile)m_file, 0, start);
+		if (start > 0) {
+			char c;
+			for (;;) {
+				c = gzgetc((gzFile)m_file);
+				if (c == EOF || c == '>' || c == '\n') {
+					break;
+				}
+			}
+			if (gzeof((gzFile)m_file))
+				cerr << m_path << ':' << section << ": warning: "
+					"there are no contigs in this section\n";
+			gzungetc('>', (gzFile)m_file);
+		}
+		assert(m_file_end > 0);
+	} else {
+		// Move the get pointer to the first entry in this section and
+		// update the m_end if there is more than one section.
+		m_in->seekg(0, ios::end);
+		streampos length = m_in->tellg();
+		assert(length > 0);
+		streampos start = length * (section - 1) / nsections;
+		streampos end = length * section / nsections;
+		assert(end > 0);
+		if (end < length) {
+			m_in->seekg(end);
+			if (m_in->peek() == '>')
+				end += 1;
+		}
+		m_end = end;
+		m_in->seekg(start);
+		if (start > 0) {
+			m_in->ignore(numeric_limits<streamsize>::max(), '\n');
+			m_in->ignore(numeric_limits<streamsize>::max(), '>');
+			if (m_in->peek() == EOF)
+				cerr << m_path << ':' << section << ": warning: "
+					"there are no contigs in this section\n";
+			m_in->putback('>');
+		}
+		assert(m_end > 0);
+		assert(m_in->good());
 	}
-	m_end = end;
-	m_in.seekg(start);
-	if (start > 0) {
-		m_in.ignore(numeric_limits<streamsize>::max(), '\n');
-		m_in.ignore(numeric_limits<streamsize>::max(), '>');
-		if (m_in.peek() == EOF)
-			cerr << m_path << ':' << section << ": warning: "
-				"there are no contigs in this section\n";
-		m_in.putback('>');
-	}
-	assert(m_end > 0);
-	assert(m_in.good());
 }
 
 /** Return whether this read passed the chastity filter. */
@@ -136,90 +229,26 @@ next_record:
 	anchor = 0;
 	q.clear();
 
-	// Discard comments.
-	while (m_in.peek() == '#')
-		ignoreLines(1);
-
-	signed char recordType = m_in.peek();
 	Sequence s;
-
 	unsigned qualityOffset = 0;
-	if (recordType == EOF || m_in.tellg() >= m_end) {
-		m_in.seekg(0, ios::end);
-		m_in.clear(std::ios::eofbit | std::ios::failbit);
-		return s;
-	} else if (recordType == '>' || recordType == '@') {
-		// Read the header.
-		string header;
-		getline(header);
-		istringstream headerStream(header);
 
-		// Ignore SAM headers.
-		if (header[0] == '@' && isalpha(header[1])
-				&& isalpha(header[2]) && header[3] == '\t')
+	if (is_fasta) {
+		if ((m_file_state = kseq_read((kseq_t*)seq_data)) < 0)
+			return s;
+
+		kseq_t *seq = (kseq_t*)seq_data;
+		if (seq->name.s != NULL) id = seq->name.s;
+		if (seq->comment.s != NULL) comment = seq->comment.s;
+		if (seq->seq.s != NULL) s = seq->seq.s;
+		if (seq->qual.s != NULL) q = seq->qual.s;
+
+		if (opt::chastityFilter && comment.length() > 2 && comment[2] == 'Y') {
+			m_unchaste++;
 			goto next_record;
-
-		headerStream >> recordType >> id >> ws;
-		std::getline(headerStream, comment);
-
-		// Casava FASTQ format
-		if (comment.size() > 3
-				&& comment[1] == ':' && comment[3] == ':') {
-			// read, chastity, flags, index: 1:Y:0:AAAAAA
-			if (opt::chastityFilter && comment[2] == 'Y') {
-				m_unchaste++;
-				if (recordType == '@') {
-					ignoreLines(3);
-				} else {
-					while (m_in.peek() != '>' && m_in.peek() != '#'
-							&& ignoreLines(1))
-						;
-				}
-				goto next_record;
-			}
-			if (id.size() > 2 && id.rbegin()[1] != '/') {
-				// Add the read number to the ID.
-				id += '/';
-				id += comment[0];
-			}
-		}
-
-		getline(s);
-		if (recordType == '>') {
-			// Read a multi-line FASTA record.
-			string line;
-			while (m_in.peek() != '>' && m_in.peek() != '#'
-					&& getline(line))
-				s += line;
-			if (m_in.eof())
-				m_in.clear();
-		}
-
-		if (recordType == '@') {
-			char c = m_in.get();
-			if (c != '+') {
-				string line;
-				getline(line);
-				die() << "expected `+' and saw ";
-				if (m_in.eof())
-					cerr << "end-of-file\n";
-				else
-					cerr << "`" << c << "' near\n"
-					<< c << line << "\n";
-				exit(EXIT_FAILURE);
-			}
-			ignoreLines(1);
-			getline(q);
-		} else
-			q.clear();
-
-		if (s.empty()) {
-			die() << "sequence with ID `" << id << "' is empty\n";
-			exit(EXIT_FAILURE);
 		}
 
 		bool colourSpace = isColourSpace(s);
-		if (colourSpace && !isdigit(s[0])) {
+		if (colourSpace && !s.empty() && !isdigit(s[0])) {
 			// The first character is the primer base. The second
 			// character is the dibase read of the primer and the
 			// first base of the sample, which is not part of the
@@ -254,105 +283,222 @@ next_record:
 
 		qualityOffset = 33;
 	} else {
-		string line;
-		vector<string> fields;
-		fields.reserve(22);
-		getline(line);
-		istringstream in(line);
-		string field;
-		while (std::getline(in, field, '\t'))
-			fields.push_back(field);
+		// Discard comments.
+		while (m_in->peek() == '#')
+			ignoreLines(1);
 
-		if (fields.size() >= 11
-				&& (fields[9].length() == fields[10].length()
-					|| fields[10] == "*")) {
-			// SAM
-			unsigned flags = strtoul(fields[1].c_str(), NULL, 0);
-			if (flags & 0x100) // FSECONDARY
+		signed char recordType = m_in->peek();
+
+		if (recordType == EOF || m_in->tellg() >= m_end) {
+			m_in->seekg(0, ios::end);
+			m_in->clear(std::ios::eofbit | std::ios::failbit);
+			return s;
+		} else if (recordType == '>' || recordType == '@') {
+			// Read the header.
+			string header;
+			getline(header);
+			istringstream headerStream(header);
+
+			// Ignore SAM headers.
+			if (header[0] == '@' && isalpha(header[1])
+					&& isalpha(header[2]) && header[3] == '\t')
 				goto next_record;
-			if (opt::chastityFilter && (flags & 0x200)) { // FQCFAIL
-				m_unchaste++;
-				goto next_record;
+
+			headerStream >> recordType >> id >> ws;
+			std::getline(headerStream, comment);
+
+			// Casava FASTQ format
+			if (comment.size() > 3
+					&& comment[1] == ':' && comment[3] == ':') {
+				// read, chastity, flags, index: 1:Y:0:AAAAAA
+				if (opt::chastityFilter && comment[2] == 'Y') {
+					m_unchaste++;
+					if (recordType == '@') {
+						ignoreLines(3);
+					} else {
+						while (m_in->peek() != '>' && m_in->peek() != '#'
+								&& ignoreLines(1))
+							;
+					}
+					goto next_record;
+				}
+				if (id.size() > 2 && id.rbegin()[1] != '/') {
+					// Add the read number to the ID.
+					id += '/';
+					id += comment[0];
+				}
 			}
-			id = fields[0];
-			char which_read = '0';
-			switch (flags & 0xc1) { // FPAIRED|FREAD1|FREAD2
-			  case 0:
-			  case 1: // FPAIRED
-				which_read = '0';
-				break;
-			  case 0x41: // FPAIRED|FREAD1
-				id += "/1";
-				which_read = '1';
-				break;
-			  case 0x81: // FPAIRED|FREAD2
-				id += "/2";
-				which_read = '2';
-				break;
-			  default:
-				die() << "invalid flags: `" << id << "' near"
-					<< line << endl;
+
+			getline(s);
+			if (recordType == '>') {
+				// Read a multi-line FASTA record.
+				string line;
+				while (m_in->peek() != '>' && m_in->peek() != '#'
+						&& getline(line))
+					s += line;
+				if (m_in->eof())
+					m_in->clear();
+			}
+
+			if (recordType == '@') {
+				char c = m_in->get();
+				if (c != '+') {
+					string line;
+					getline(line);
+					die() << "expected `+' and saw ";
+					if (m_in->eof())
+						cerr << "end-of-file\n";
+					else
+						cerr << "`" << c << "' near\n"
+						<< c << line << "\n";
+					exit(EXIT_FAILURE);
+				}
+				ignoreLines(1);
+				getline(q);
+			} else
+				q.clear();
+
+			if (s.empty()) {
+				die() << "sequence with ID `" << id << "' is empty\n";
 				exit(EXIT_FAILURE);
 			}
-			if (opt::bxTag) {
-				// Copy the linked-reads barcode BX tag to the FASTA comment.
-				for (unsigned i = 11; i < fields.size(); ++i) {
-					if (startsWith(fields[i], "BX:Z:")) {
-						comment = fields[i];
-						break;
-					}
-				}
-			} else {
-				comment = flags & 0x200 ? "0:Y:0:" : "0:N:0:"; // FQCFAIL
-				comment[0] = which_read;
+
+			bool colourSpace = isColourSpace(s);
+			if (colourSpace && !isdigit(s[0])) {
+				// The first character is the primer base. The second
+				// character is the dibase read of the primer and the
+				// first base of the sample, which is not part of the
+				// assembly.
+				assert(s.length() > 2);
+				anchor = colourToNucleotideSpace(s[0], s[1]);
+				s.erase(0, 2);
+				q.erase(0, 1);
 			}
 
-			s = fields[9];
-			q = fields[10];
-			if (s == "*")
-				s.clear();
-			if (q == "*")
-				q.clear();
-			if (flags & 0x10) { // FREVERSE
-				s = reverseComplement(s);
-				reverse(q.begin(), q.end());
-			}
-			qualityOffset = 33;
 			if (!q.empty())
 				checkSeqQual(s, q);
 
-		} else if (fields.size() == 11 || fields.size() == 22) {
-			// qseq or export
-			if (opt::chastityFilter
-					&& !isChaste(fields.back(), line)) {
-				m_unchaste++;
-				goto next_record;
+			if (opt::trimMasked && !colourSpace) {
+				// Removed masked (lower case) sequence at the beginning
+				// and end of the read.
+				size_t trimFront = 0;
+				while (trimFront <= s.length() && islower(s[trimFront]))
+					trimFront++;
+				size_t trimBack = s.length();
+				while (trimBack > 0 && islower(s[trimBack - 1]))
+					trimBack--;
+				s.erase(trimBack);
+				s.erase(0, trimFront);
+				if (!q.empty()) {
+					q.erase(trimBack);
+					q.erase(0, trimFront);
+				}
 			}
+			if (flagFoldCase())
+				transform(s.begin(), s.end(), s.begin(), ::toupper);
 
-			ostringstream o;
-			o << fields[0];
-			for (int i = 1; i < 6; i++)
-				if (!fields[i].empty())
-					o << ':' << fields[i];
-			if (!fields[6].empty() && fields[6] != "0")
-				o << '#' << fields[6];
-			// The reverse read is typically the second read, but is
-			// the third read of an indexed run.
-			o << '/' << (fields[7] == "3" ? "2" : fields[7]);
-			id = o.str();
-			comment = fields[7];
-			comment += isChaste(fields.back(), line)
-				? ":N:0:" : ":Y:0:";
-			s = fields[8];
-			q = fields[9];
-			qualityOffset = 64;
-			checkSeqQual(s, q);
+			qualityOffset = 33;
 		} else {
-			die() << "Expected either `>' or `@' or 11 fields\n"
-					"and saw `" << recordType << "' and "
-					<< fields.size() << " fields near\n"
-					<< line << endl;
-			exit(EXIT_FAILURE);
+			string line;
+			vector<string> fields;
+			fields.reserve(22);
+			getline(line);
+			istringstream in(line);
+			string field;
+			while (std::getline(in, field, '\t'))
+				fields.push_back(field);
+
+			if (fields.size() >= 11
+					&& (fields[9].length() == fields[10].length()
+						|| fields[10] == "*")) {
+				// SAM
+				unsigned flags = strtoul(fields[1].c_str(), NULL, 0);
+				if (flags & 0x100) // FSECONDARY
+					goto next_record;
+				if (opt::chastityFilter && (flags & 0x200)) { // FQCFAIL
+					m_unchaste++;
+					goto next_record;
+				}
+				id = fields[0];
+				char which_read = '0';
+				switch (flags & 0xc1) { // FPAIRED|FREAD1|FREAD2
+				  case 0:
+				  case 1: // FPAIRED
+					which_read = '0';
+					break;
+				  case 0x41: // FPAIRED|FREAD1
+					id += "/1";
+					which_read = '1';
+					break;
+				  case 0x81: // FPAIRED|FREAD2
+					id += "/2";
+					which_read = '2';
+					break;
+				  default:
+					die() << "invalid flags: `" << id << "' near"
+						<< line << endl;
+					exit(EXIT_FAILURE);
+				}
+				if (opt::bxTag) {
+					// Copy the linked-reads barcode BX tag to the FASTA comment.
+					for (unsigned i = 11; i < fields.size(); ++i) {
+						if (startsWith(fields[i], "BX:Z:")) {
+							comment = fields[i];
+							break;
+						}
+					}
+				} else {
+					comment = flags & 0x200 ? "0:Y:0:" : "0:N:0:"; // FQCFAIL
+					comment[0] = which_read;
+				}
+
+				s = fields[9];
+				q = fields[10];
+				if (s == "*")
+					s.clear();
+				if (q == "*")
+					q.clear();
+				if (flags & 0x10) { // FREVERSE
+					s = reverseComplement(s);
+					reverse(q.begin(), q.end());
+				}
+				qualityOffset = 33;
+				if (!q.empty())
+					checkSeqQual(s, q);
+
+			} else if (fields.size() == 11 || fields.size() == 22) {
+				// qseq or export
+				if (opt::chastityFilter
+						&& !isChaste(fields.back(), line)) {
+					m_unchaste++;
+					goto next_record;
+				}
+
+				ostringstream o;
+				o << fields[0];
+				for (int i = 1; i < 6; i++)
+					if (!fields[i].empty())
+						o << ':' << fields[i];
+				if (!fields[6].empty() && fields[6] != "0")
+					o << '#' << fields[6];
+				// The reverse read is typically the second read, but is
+				// the third read of an indexed run.
+				o << '/' << (fields[7] == "3" ? "2" : fields[7]);
+				id = o.str();
+				comment = fields[7];
+				comment += isChaste(fields.back(), line)
+					? ":N:0:" : ":Y:0:";
+				s = fields[8];
+				q = fields[9];
+				qualityOffset = 64;
+				checkSeqQual(s, q);
+			} else {
+				die() << "Expected either `>' or `@' or 11 fields\n"
+						"and saw `" << recordType << "' and "
+						<< fields.size() << " fields near\n"
+						<< line << endl;
+				exit(EXIT_FAILURE);
+			}
 		}
 	}
 

--- a/DataLayer/Makefile.am
+++ b/DataLayer/Makefile.am
@@ -4,14 +4,14 @@ noinst_LIBRARIES = libdatalayer.a
 abyss_fac_CPPFLAGS = -I$(top_srcdir)
 
 abyss_fac_LDADD = libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_fac_SOURCES = fac.cc
 
 abyss_tofastq_CPPFLAGS = -I$(top_srcdir)
 
 abyss_tofastq_LDADD = libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_tofastq_SOURCES = abyss-tofastq.cc
 

--- a/DataLayer/kseq.h
+++ b/DataLayer/kseq.h
@@ -1,0 +1,224 @@
+/* The MIT License
+
+   Copyright (c) 2008, 2009, 2011 Attractive Chaos <attractor@live.co.uk>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+/* Last Modified: 18AUG2011 */
+
+#ifndef AC_KSEQ_H
+#define AC_KSEQ_H
+
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define KS_SEP_SPACE 0 // isspace(): \t, \n, \v, \f, \r
+#define KS_SEP_TAB   1 // isspace() && !' '
+#define KS_SEP_MAX   1
+
+#define __KS_TYPE(type_t)						\
+	typedef struct __kstream_t {				\
+		unsigned char *buf;						\
+		int begin, end, is_eof;					\
+		type_t f;								\
+	} kstream_t;
+
+#define ks_eof(ks) ((ks)->is_eof && (ks)->begin >= (ks)->end)
+#define ks_rewind(ks) ((ks)->is_eof = (ks)->begin = (ks)->end = 0)
+
+#define __KS_BASIC(type_t, __bufsize)								\
+	static inline kstream_t *ks_init(type_t f)						\
+	{																\
+		kstream_t *ks = (kstream_t*)calloc(1, sizeof(kstream_t));	\
+		ks->f = f;													\
+		ks->buf = (unsigned char*)malloc(__bufsize);				\
+		return ks;													\
+	}																\
+	static inline void ks_destroy(kstream_t *ks)					\
+	{																\
+		if (ks) {													\
+			free(ks->buf);											\
+			free(ks);												\
+		}															\
+	}
+
+#define __KS_GETC(__read, __bufsize)						\
+	static inline int ks_getc(kstream_t *ks)				\
+	{														\
+		if (ks->is_eof && ks->begin >= ks->end) return -1;	\
+		if (ks->begin >= ks->end) {							\
+			ks->begin = 0;									\
+			ks->end = __read(ks->f, ks->buf, __bufsize);	\
+			if (ks->end < __bufsize) ks->is_eof = 1;		\
+			if (ks->end == 0) return -1;					\
+		}													\
+		return (int)ks->buf[ks->begin++];					\
+	}
+
+#ifndef KSTRING_T
+#define KSTRING_T kstring_t
+typedef struct __kstring_t {
+	size_t l, m;
+	char *s;
+} kstring_t;
+#endif
+
+#ifndef kroundup32
+#define kroundup32(x) (--(x), (x)|=(x)>>1, (x)|=(x)>>2, (x)|=(x)>>4, (x)|=(x)>>8, (x)|=(x)>>16, ++(x))
+#endif
+
+#define __KS_GETUNTIL(__read, __bufsize)								\
+	static int ks_getuntil2(kstream_t *ks, int delimiter, kstring_t *str, int *dret, int append) \
+	{																	\
+		if (dret) *dret = 0;											\
+		str->l = append? str->l : 0;									\
+		if (ks->begin >= ks->end && ks->is_eof) return -1;				\
+		for (;;) {														\
+			int i;														\
+			if (ks->begin >= ks->end) {									\
+				if (!ks->is_eof) {										\
+					ks->begin = 0;										\
+					ks->end = __read(ks->f, ks->buf, __bufsize);		\
+					if (ks->end < __bufsize) ks->is_eof = 1;			\
+					if (ks->end == 0) break;							\
+				} else break;											\
+			}															\
+			if (delimiter > KS_SEP_MAX) {								\
+				for (i = ks->begin; i < ks->end; ++i)					\
+					if (ks->buf[i] == delimiter) break;					\
+			} else if (delimiter == KS_SEP_SPACE) {						\
+				for (i = ks->begin; i < ks->end; ++i)					\
+					if (isspace(ks->buf[i])) break;						\
+			} else if (delimiter == KS_SEP_TAB) {						\
+				for (i = ks->begin; i < ks->end; ++i)					\
+					if (isspace(ks->buf[i]) && ks->buf[i] != ' ') break; \
+			} else i = 0; /* never come to here! */						\
+			if (str->m - str->l < (size_t)i - ks->begin + 1) {			\
+				str->m = str->l + (i - ks->begin) + 1;					\
+				kroundup32(str->m);										\
+				str->s = (char*)realloc(str->s, str->m);				\
+			}															\
+			memcpy(str->s + str->l, ks->buf + ks->begin, i - ks->begin); \
+			str->l = str->l + (i - ks->begin);							\
+			ks->begin = i + 1;											\
+			if (i < ks->end) {											\
+				if (dret) *dret = ks->buf[i];							\
+				break;													\
+			}															\
+		}																\
+		if (str->s == 0) {												\
+			str->m = 1;													\
+			str->s = (char*)calloc(1, 1);								\
+		}																\
+		str->s[str->l] = '\0';											\
+		return str->l;													\
+	} \
+	static inline int ks_getuntil(kstream_t *ks, int delimiter, kstring_t *str, int *dret) \
+	{ return ks_getuntil2(ks, delimiter, str, dret, 0); }
+
+#define KSTREAM_INIT(type_t, __read, __bufsize) \
+	__KS_TYPE(type_t)							\
+	__KS_BASIC(type_t, __bufsize)				\
+	__KS_GETC(__read, __bufsize)				\
+	__KS_GETUNTIL(__read, __bufsize)
+
+#define __KSEQ_BASIC(type_t)											\
+	static inline kseq_t *kseq_init(type_t fd)							\
+	{																	\
+		kseq_t *s = (kseq_t*)calloc(1, sizeof(kseq_t));					\
+		s->f = ks_init(fd);												\
+		return s;														\
+	}																	\
+	static inline void kseq_rewind(kseq_t *ks)							\
+	{																	\
+		ks->last_char = 0;												\
+		ks->f->is_eof = ks->f->begin = ks->f->end = 0;					\
+	}																	\
+	static inline void kseq_destroy(kseq_t *ks)							\
+	{																	\
+		if (!ks) return;												\
+		free(ks->name.s); free(ks->comment.s); free(ks->seq.s);	free(ks->qual.s); \
+		ks_destroy(ks->f);												\
+		free(ks);														\
+	}
+
+/* Return value:
+   >=0  length of the sequence (normal)
+   -1   end-of-file
+   -2   truncated quality string
+ */
+#define __KSEQ_READ \
+	static int kseq_read(kseq_t *seq) \
+	{ \
+		int c; \
+		kstream_t *ks = seq->f; \
+		if (seq->last_char == 0) { /* then jump to the next header line */ \
+			while ((c = ks_getc(ks)) != -1 && c != '>' && c != '@'); \
+			if (c == -1) return -1; /* end of file */ \
+			seq->last_char = c; \
+		} /* else: the first header char has been read in the previous call */ \
+		seq->comment.l = seq->seq.l = seq->qual.l = 0; /* reset all members */ \
+		if (ks_getuntil(ks, 0, &seq->name, &c) < 0) return -1; /* normal exit: EOF */ \
+		if (c != '\n') ks_getuntil(ks, '\n', &seq->comment, 0); /* read FASTA/Q comment */ \
+		if (seq->seq.s == 0) { /* we can do this in the loop below, but that is slower */ \
+			seq->seq.m = 256; \
+			seq->seq.s = (char*)malloc(seq->seq.m); \
+		} \
+		while ((c = ks_getc(ks)) != -1 && c != '>' && c != '+' && c != '@') { \
+			seq->seq.s[seq->seq.l++] = c; /* this is safe: we always have enough space for 1 char */ \
+			ks_getuntil2(ks, '\n', &seq->seq, 0, 1); /* read the rest of the line */ \
+		} \
+		if (c == '>' || c == '@') seq->last_char = c; /* the first header char has been read */	\
+		if (seq->seq.l + 1 >= seq->seq.m) { /* seq->seq.s[seq->seq.l] below may be out of boundary */ \
+			seq->seq.m = seq->seq.l + 2; \
+			kroundup32(seq->seq.m); /* rounded to the next closest 2^k */ \
+			seq->seq.s = (char*)realloc(seq->seq.s, seq->seq.m); \
+		} \
+		seq->seq.s[seq->seq.l] = 0;	/* null terminated string */ \
+		if (c != '+') return seq->seq.l; /* FASTA */ \
+		if (seq->qual.m < seq->seq.m) {	/* allocate memory for qual in case insufficient */ \
+			seq->qual.m = seq->seq.m; \
+			seq->qual.s = (char*)realloc(seq->qual.s, seq->qual.m); \
+		} \
+		while ((c = ks_getc(ks)) != -1 && c != '\n'); /* skip the rest of '+' line */ \
+		if (c == -1) return -2; /* error: no quality string */ \
+		while (ks_getuntil2(ks, '\n', &seq->qual, 0, 1) >= 0 && seq->qual.l < seq->seq.l); \
+		seq->last_char = 0;	/* we have not come to the next header line */ \
+		if (seq->seq.l != seq->qual.l) return -2; /* error: qual string is of a different length */ \
+		return seq->seq.l; \
+	}
+
+#define __KSEQ_TYPE(type_t)						\
+	typedef struct {							\
+		kstring_t name, comment, seq, qual;		\
+		int last_char;							\
+		kstream_t *f;							\
+	} kseq_t;
+
+#define KSEQ_INIT(type_t, __read)				\
+	KSTREAM_INIT(type_t, __read, 16384)			\
+	__KSEQ_TYPE(type_t)							\
+	__KSEQ_BASIC(type_t)						\
+	__KSEQ_READ
+
+#endif

--- a/FilterGraph/Makefile.am
+++ b/FilterGraph/Makefile.am
@@ -8,6 +8,6 @@ abyss_filtergraph_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 
 abyss_filtergraph_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_filtergraph_SOURCES = FilterGraph.cc

--- a/GapFiller/Makefile.am
+++ b/GapFiller/Makefile.am
@@ -12,6 +12,6 @@ abyss_gapfill_LDADD = \
 	$(top_builddir)/Align/libalign.a \
     $(top_builddir)/dialign/libdialign.a \
     $(top_builddir)/DataLayer/libdatalayer.a \
-    $(top_builddir)/Common/libcommon.a
+    $(top_builddir)/Common/libcommon.a -lz
 
 abyss_gapfill_SOURCES = gapfill.cpp gapfill.h

--- a/KAligner/Makefile.am
+++ b/KAligner/Makefile.am
@@ -7,7 +7,7 @@ KAligner_CPPFLAGS = -I$(top_srcdir) \
 KAligner_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Common/libcommon.a \
-	-lpthread
+	-lpthread -lz
 
 KAligner_SOURCES = KAligner.cpp Aligner.cpp Aligner.h Options.h \
 	Pipe.h PipeMux.h Semaphore.h

--- a/Konnector/Makefile.am
+++ b/Konnector/Makefile.am
@@ -9,7 +9,7 @@ konnector_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 konnector_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 konnector_SOURCES = konnector.cc \
 	DBGBloom.h \

--- a/LogKmerCount/Makefile.am
+++ b/LogKmerCount/Makefile.am
@@ -9,7 +9,7 @@ logcounter_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 logcounter_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 logcounter_SOURCES = logcounter.cc \
 	CountingBloomFilter.h \

--- a/Map/Makefile.am
+++ b/Map/Makefile.am
@@ -8,7 +8,7 @@ abyss_index_CPPFLAGS = -I$(top_srcdir) \
 abyss_index_LDADD = \
 	$(top_builddir)/FMIndex/libfmindex.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_index_SOURCES = index.cc
 
@@ -24,7 +24,7 @@ abyss_map_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Common/libcommon.a \
 	$(top_builddir)/DataBase/libdb.a \
-	$(SQLITE_LIBS)
+	$(SQLITE_LIBS) -lz
 
 abyss_map_SOURCES = map.cc
 
@@ -33,7 +33,7 @@ abyss_map_ssq_CPPFLAGS = $(abyss_map_CPPFLAGS) \
 
 abyss_map_ssq_CXXFLAGS = $(abyss_map_CXXFLAGS)
 
-abyss_map_ssq_LDADD = $(abyss_map_LDADD)
+abyss_map_ssq_LDADD = $(abyss_map_LDADD) -lz
 
 abyss_map_ssq_SOURCES = $(abyss_map_SOURCES)
 
@@ -47,6 +47,6 @@ abyss_overlap_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 abyss_overlap_LDADD = \
 	$(top_builddir)/FMIndex/libfmindex.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_overlap_SOURCES = overlap.cc

--- a/MergePaths/Makefile.am
+++ b/MergePaths/Makefile.am
@@ -10,7 +10,7 @@ MergePaths_LDADD = \
 	$(top_builddir)/DataBase/libdb.a \
 	$(SQLITE_LIBS) \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 MergePaths_SOURCES = \
 	MergePaths.cpp
@@ -25,7 +25,7 @@ MergeContigs_LDADD = \
 	$(SQLITE_LIBS) \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 MergeContigs_SOURCES = MergeContigs.cpp
 
@@ -41,7 +41,7 @@ PathConsensus_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
 	$(top_builddir)/Common/libcommon.a \
-	$(top_builddir)/dialign/libdialign.a
+	$(top_builddir)/dialign/libdialign.a -lz
 
 PathConsensus_SOURCES = \
 	PathConsensus.cpp

--- a/Overlap/Makefile.am
+++ b/Overlap/Makefile.am
@@ -6,7 +6,7 @@ Overlap_CPPFLAGS = -I$(top_srcdir) \
 
 Overlap_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 Overlap_SOURCES = \
 	Overlap.cpp

--- a/PairedDBG/Makefile.am
+++ b/PairedDBG/Makefile.am
@@ -13,7 +13,7 @@ abyss_paired_dbg_LDADD = \
 	$(top_builddir)/Assembly/libassembly.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Common/libcommon.a \
-	$(libdb)
+	$(libdb) -lz
 
 abyss_paired_dbg_SOURCES = \
 	abyss-paired-dbg.cc \

--- a/Parallel/Makefile.am
+++ b/Parallel/Makefile.am
@@ -12,7 +12,7 @@ ABYSS_P_LDADD = \
 	$(top_builddir)/Common/libcommon.a \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(libdb) \
-	$(MPI_LIBS)
+	$(MPI_LIBS) -lz
 
 ABYSS_P_SOURCES = \
 	parallelAbyss.cpp \

--- a/PopBubbles/Makefile.am
+++ b/PopBubbles/Makefile.am
@@ -11,6 +11,6 @@ PopBubbles_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
 	$(top_builddir)/Common/libcommon.a \
-	$(top_builddir)/dialign/libdialign.a
+	$(top_builddir)/dialign/libdialign.a -lz
 
 PopBubbles_SOURCES = PopBubbles.cpp

--- a/Sealer/Makefile.am
+++ b/Sealer/Makefile.am
@@ -15,7 +15,7 @@ abyss_sealer_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 abyss_sealer_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a -lz
 
 abyss_sealer_SOURCES = sealer.cc \
 	$(top_srcdir)/Bloom/BloomFilter.h \


### PR DESCRIPTION
Some notes:
- kseq.h requires zlib, so I had to add it to linker flags to several Makefile.am-s.
- Most of the time dealing with fasta/fastq files is spent unzipping them (if they're zipped), but because of zlib, kseq.h allows for extracting while reading, instead of extracting the whole file, which is slightly faster.
- Because kseq.h doesn't have peek(), there's a filename based check to see whether the file is fasta/fastq, otherwise it falls back to original implementation.