### PR TITLE
Add MPI functionality to Sealer

### DIFF
--- a/Sealer/Makefile.am
+++ b/Sealer/Makefile.am
@@ -15,7 +15,8 @@ abyss_sealer_CXXFLAGS = $(AM_CXXFLAGS) $(OPENMP_CXXFLAGS)
 abyss_sealer_LDADD = \
 	$(top_builddir)/DataLayer/libdatalayer.a \
 	$(top_builddir)/Align/libalign.a \
-	$(top_builddir)/Common/libcommon.a
+	$(top_builddir)/Common/libcommon.a \
+	$(MPI_LIBS)
 
 abyss_sealer_SOURCES = sealer.cc \
 	$(top_srcdir)/Bloom/BloomFilter.h \

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -885,10 +885,10 @@ void send_string(const string& str, int target_pid) {
 }
 
 void send_closedgap(const ClosedGap& gap, int target_pid) {
-	MPI_Send(&gap.left.start, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
-	MPI_Send(&gap.left.end, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
-	MPI_Send(&gap.right.start, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
-	MPI_Send(&gap.right.end, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
+	MPI_Send((void*)&gap.left.start, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
+	MPI_Send((void*)&gap.left.end, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
+	MPI_Send((void*)&gap.right.start, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
+	MPI_Send((void*)&gap.right.end, 1, MPI_INT, target_pid, 0, MPI_COMM_WORLD);
 	send_string(gap.seq, target_pid);
 }
 

--- a/bin/abyss-pe
+++ b/bin/abyss-pe
@@ -818,7 +818,7 @@ endif
 sealer_ks?=-k90 -k80 -k70 -k60 -k50 -k40 -k30
 
 %-8_scaffold.fa: %-8.fa
-	abyss-sealer -v -j$j --print-flanks -o$*-8 -S$< $(sealer_ks) $(SEALER_OPTIONS) $(in) $(se)
+	$(mpirun) -np $(np) --bind-to none abyss-sealer -v -j$j --print-flanks -o$*-8 -S$< $(sealer_ks) $(SEALER_OPTIONS) $(in) $(se)
 
 %-scaffolds-sealed.fa: %-8_scaffold.fa
 	ln -s $< $@


### PR DESCRIPTION
Here's the MPI version of Sealer I was working on, in case it ends up being useful. (I understand MPI is being phased out, I am posting this in case somebody has super long Sealer jobs until then, and it was good practice for me.)

The way it works is it splits the processes into groups, with each group closing gaps for a particular value of k, so it scales by both the number of k values and the number of gaps to be closed. After k values are processed by all groups, closed gaps are compared and corrections are made so that the gaps closed by later values of k are erased if the gaps were closed by earlier k values. After all k values are processed, the closed gaps are gathered at root process which then writes it to a file, as before. Processes also each have their own log files which are merged in the end into a single file.

For example, for a Sealer job that lasts 16 minutes, time was brought down to about 3 minutes for a 7 node job, where each k value gets its own node (by default, there are 7 k values for Sealer).

I have also tested various number of nodes for the job, ranging from 1 to 20 and the output is identical to the output of original Sealer.