### PR TITLE
Add --median option to DistanceEst

### DIFF
--- a/Common/PMF.h
+++ b/Common/PMF.h
@@ -15,7 +15,7 @@ class PMF
   public:
 	/** Construct a PMF from a histogram. */
 	PMF(const Histogram& h)
-		: m_dist(h.maximum() + 1), m_mean(h.mean()), m_stdDev(h.sd())
+		: m_dist(h.maximum() + 1), m_mean(h.mean()), m_stdDev(h.sd()), m_median(h.median())
 	{
 		unsigned count = h.size();
 		m_minp = (double)1 / count;
@@ -44,6 +44,9 @@ class PMF
 		return m_dist.size() - 1;
 	}
 
+	/** Return the median of this distribution. */
+	int median() const { return m_median; }
+
 	/** Return the mean of this distribution. */
 	double mean() const { return m_mean; }
 
@@ -60,6 +63,7 @@ class PMF
 	double m_mean;
 	double m_stdDev;
 	double m_minp;
+	int m_median;
 };
 
 namespace std {

--- a/bin/abyss-pe
+++ b/bin/abyss-pe
@@ -342,7 +342,7 @@ SCAFFOLD_DE_OPTIONS?=$(DISTANCEEST_OPTIONS)
 $(foreach i,$(mp),$(eval $i_l?=$L))
 $(foreach i,$(mp),$(eval $i_s?=$(SCAFFOLD_DE_S)))
 $(foreach i,$(mp),$(eval $i_n?=$(SCAFFOLD_DE_N)))
-override scaffold_deopt=$v $(dbopt) --dot --mean -j$j -k$k $(SCAFFOLD_DE_OPTIONS) -l$($*_l) -s$($*_s) -n$($*_n) $($*_de)
+override scaffold_deopt=$v $(dbopt) --dot --median -j$j -k$k $(SCAFFOLD_DE_OPTIONS) -l$($*_l) -s$($*_s) -n$($*_n) $($*_de)
 scopt += $v $(dbopt) $(SS) -k$k
 ifdef G
 scopt += -G$G


### PR DESCRIPTION
Adding ```--median``` option to DistanceEst: Uses difference between population and sample medians to estimate the distances. Also changed ```abyss-pe``` to use this option by default in the scaffolding stage.