### PR TITLE
Fix failure to build on 32-bit architectures

### DIFF
--- a/Common/StringUtil.h
+++ b/Common/StringUtil.h
@@ -178,7 +178,7 @@ bool isReadNamePair(const std::string& name1, const std::string& name2)
 	return false;
 }
 
-static inline size_t SIToBytes(std::istringstream& iss)
+static inline unsigned long long SIToBytes(std::istringstream& iss)
 {
 	double size;
 	std::string units;
@@ -194,7 +194,7 @@ static inline size_t SIToBytes(std::istringstream& iss)
 		// no units given; clear fail flag
 		// and assume bytes
 		iss.clear(std::ios::eofbit);
-		return (size_t)ceil(size);
+		return (unsigned long long)ceil(size);
 	}
 
 	if (units.size() > 1) {


### PR DESCRIPTION
Version 1.5.2-1 of abyss fails to build from source on 32-bit architectures (armhf, i386 and powerpc). Previous versions built fine on all architectures. . There were a couple of places in the code that was introduced in version 1.5.2 where size_t data type was used instead of a fixed size data type. The patch builds on amd64, i386 and armhf with and all unit tests passed.