### PR TITLE
Fixed small typo on the command for paired de Bruijn graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ To assemble using paired de Bruijn graph mode, specify both individual
 k-mer size (`K`) and k-mer pair span (`k`). For example, to assemble E.
 coli with a individual k-mer size of 16 and a k-mer pair span of 64:
 
-	abyss-pe name=ecoli K=16 k=96 in='reads1.fa reads2.fa'
+	abyss-pe name=ecoli K=16 k=64 in='reads1.fa reads2.fa'
 
 In this example, the size of the intervening gap between k-mer pairs is
 32 bp (64 - 2\*16). Note that the `k` parameter takes on a new meaning


### PR DESCRIPTION
The text around the code snippet used 64 as the span whereas the command used 96.