### PR TITLE
Fix build on big-endian FreeBSD

### DIFF
--- a/Common/city.cc
+++ b/Common/city.cc
@@ -65,6 +65,11 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
 #define bswap_32(x) OSSwapInt32(x)
 #define bswap_64(x) OSSwapInt64(x)
 
+#elif defined(__FreeBSD__)
+#include <sys/endian.h>
+#define bswap_32(x) bswap32(x)
+#define bswap_64(x) bswap64(x)
+
 #else
 #include <byteswap.h>
 #endif


### PR DESCRIPTION
FreeBSD uses sys/endian.h header for byte-swapping and bswap*(x) functions.