### PR TITLE
README: update test data hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Run the command
 
 ## Assemble a small synthetic data set
 
-	wget http://www.bcgsc.ca/platform/bioinfo/software/abyss/releases/1.3.4/test-data.tar.gz
+	wget https://www.bcgsc.ca/sites/default/files/bioinformatics/software/abyss/releases/1.3.4/test-data.tar.gz
 	tar xzvf test-data.tar.gz
 	abyss-pe k=25 name=test \
 		in='test-data/reads1.fastq test-data/reads2.fastq'


### PR DESCRIPTION
The old test data broke when the bcgsc website underwent some updates. This link has now been updated.