### PR TITLE
DirectedGraph.h: remove unnecessary parameter to copy constructor

### DIFF
--- a/Graph/DirectedGraph.h
+++ b/Graph/DirectedGraph.h
@@ -548,7 +548,7 @@ class Edge
   protected:
 
 	/** Copy constructors */
-	DirectedGraph(const DirectedGraph& d) = default;
+	DirectedGraph(const DirectedGraph&) = default;
 	DirectedGraph(DirectedGraph&&) = default;
 	DirectedGraph& operator=(const DirectedGraph&) = default;
 	DirectedGraph& operator=(DirectedGraph&&) = default;


### PR DESCRIPTION
@jowong4 I hope you don't mind me jumping in on this but I was in the neighborhood and stumbled across #321 myself. Apologies if you had already started addressing this. @lmjakt, can you confirm this resolves your issue?

From the truncated error message on #320, I'm guessing that has the same root cause and is also fixed by this. @sunnykevin19, does this solve your issue?