### PR TITLE
abyss: detect 'ar' tool via AM_PROG_AR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Makefile
 Makefile.in
 README.html
 aclocal.m4
+ar-lib
 autom4te.cache
 config.guess
 config.h

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,7 @@ AC_CHECK_TOOL(GHC, ghc)
 AM_CONDITIONAL([HAVE_GHC], ["$GHC" --version])
 AC_CHECK_PROG(PANDOC, pandoc, yes)
 AM_CONDITIONAL([HAVE_PANDOC], [test x"$PANDOC" = x"yes"])
+AM_PROG_AR
 
 # Checks for header files.
 AC_CHECK_HEADERS([dlfcn.h fcntl.h float.h limits.h \


### PR DESCRIPTION
Before the change
    $ ./configure --host=x86_64-pc-linux-gnu && make
was referring to 'ar' tool.

After the change it refers to 'x86_64-pc-linux-gnu-ar'
tool if that exists. This helps user to consistently
pick 'ar' implementation.

Reported-by: Agostino Sarubbo
Bug: https://bugs.gentoo.org/725300