### PR TITLE
Capture all tags in sam file

### DIFF
--- a/Common/SAM.h
+++ b/Common/SAM.h
@@ -340,8 +340,8 @@ struct SAMRecord : SAMAlignment {
 #if SAM_SEQ_QUAL
 		in >> o.seq >> o.qual;
 		getline(in, o.tags);
-#endif
-#if !SAM_SEQ_QUAL
+		o.tags = o.tags.substr(1);
+#else
 		in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 #endif
 		if (!in)

--- a/Common/SAM.h
+++ b/Common/SAM.h
@@ -339,15 +339,7 @@ struct SAMRecord : SAMAlignment {
 			>> o.cigar >> o.mrnm >> o.mpos >> o.isize;
 #if SAM_SEQ_QUAL
 		in >> o.seq >> o.qual;
-		std::string allTags = "";
-		if (in.peek() != '\n')
-			in >> allTags;
-		while (in.peek() != '\n' && !in.eof()) {
-		    std::string tag = "";
-			in >> tag;
-			allTags += "\t" + tag;
-		}
-		o.tags = allTags;
+		getline(in, o.tags);
 #endif
 		in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 		if (!in)

--- a/Common/SAM.h
+++ b/Common/SAM.h
@@ -339,8 +339,7 @@ struct SAMRecord : SAMAlignment {
 			>> o.cigar >> o.mrnm >> o.mpos >> o.isize;
 #if SAM_SEQ_QUAL
 		in >> o.seq >> o.qual;
-		getline(in, o.tags);
-		o.tags = o.tags.substr(1);
+		getline(in >> Skip('\t'), o.tags);
 #else
 		in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 #endif

--- a/Common/SAM.h
+++ b/Common/SAM.h
@@ -341,7 +341,9 @@ struct SAMRecord : SAMAlignment {
 		in >> o.seq >> o.qual;
 		getline(in, o.tags);
 #endif
+#if !SAM_SEQ_QUAL
 		in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+#endif
 		if (!in)
 			return in;
 		o.pos--;

--- a/Common/SAM.h
+++ b/Common/SAM.h
@@ -339,8 +339,15 @@ struct SAMRecord : SAMAlignment {
 			>> o.cigar >> o.mrnm >> o.mpos >> o.isize;
 #if SAM_SEQ_QUAL
 		in >> o.seq >> o.qual;
+		std::string allTags;
 		if (in.peek() != '\n')
-			in >> o.tags;
+			in >> allTags;
+		while (in.peek() != '\n' && !in.eof()) {
+		    std::string tag;
+			in >> tag;
+			allTags += "\t" + tag;
+		}
+		o.tags = allTags;
 #endif
 		in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
 		if (!in)

--- a/Common/SAM.h
+++ b/Common/SAM.h
@@ -339,11 +339,11 @@ struct SAMRecord : SAMAlignment {
 			>> o.cigar >> o.mrnm >> o.mpos >> o.isize;
 #if SAM_SEQ_QUAL
 		in >> o.seq >> o.qual;
-		std::string allTags;
+		std::string allTags = "";
 		if (in.peek() != '\n')
 			in >> allTags;
 		while (in.peek() != '\n' && !in.eof()) {
-		    std::string tag;
+		    std::string tag = "";
 			in >> tag;
 			allTags += "\t" + tag;
 		}

--- a/Unittest/Common/SAM.cc
+++ b/Unittest/Common/SAM.cc
@@ -1,7 +1,8 @@
 #include <sstream>
 #include <string>
+
 #include "Common/SAM.h"
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 /** Verify SAM records are stored and used correctly */
 

--- a/Unittest/Common/SAM.cc
+++ b/Unittest/Common/SAM.cc
@@ -68,7 +68,14 @@ TEST(parseCigarDeath, invalid_cigar)
 // Test friend std::istream& operator >>(std::istream& in, SAMRecord& o)
 TEST(parseSAMInput, check_values)
 {
-	std::string testSAMString("1:497:R:-272+13M17D24M	113	1	497	37	37M	15	100338662	0	CGGGTCTGACCTGAGGAGAACTGTGCTCCGCCTTCAG	0;==-==9;>>>>>=>>>>>>>>>>>=>>>>>>>>>>	XT:A:U	NM:i:0	SM:i:37	AM:i:0	X0:i:1	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37\n19:20389:F:275+18M2D19M	99	1	17644	0	37M	=	17919	314	TATGACTGCTAATAATACCTACACATGTTAGAACCAT	>>>>>>>>>>>>>>>>>>>><<>>><<>>4::>>:<9	RG:Z:UM0098:1	XT:A:R	NM:i:0	SM:i:0	AM:i:0	X0:i:4	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37");
+	std::string testSAMString(  "1:497:R:-272+13M17D24M	113	1	497	37	37M	15	100338662	0	"
+								"CGGGTCTGACCTGAGGAGAACTGTGCTCCGCCTTCAG	0;==-==9;>>>>>=>>>>>>>>>>>=>>>>>>>>>>	"
+								"XT:A:U	NM:i:0	SM:i:37	AM:i:0	X0:i:1	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37"
+								"\n" 
+								"19:20389:F:275+18M2D19M	99	1	17644	0	37M	=	17919	314	"
+								"TATGACTGCTAATAATACCTACACATGTTAGAACCAT	>>>>>>>>>>>>>>>>>>>><<>>><<>>4::>>:<9	"
+								"RG:Z:UM0098:1	XT:A:R	NM:i:0	SM:i:0	AM:i:0	X0:i:4	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37"
+								);
 	std::istringstream testSAMIStringStream(testSAMString);
 	SAMRecord testSAMRecord;
 	testSAMIStringStream >> testSAMRecord;

--- a/Unittest/Common/SAM.cc
+++ b/Unittest/Common/SAM.cc
@@ -1,3 +1,5 @@
+#include <sstream>
+#include <string>
 #include "Common/SAM.h"
 #include <gtest/gtest.h>
 
@@ -61,4 +63,43 @@ TEST(parseCigarDeath, invalid_cigar)
 {
 	EXPECT_DEATH(SAMAlignment::parseCigar("20SS", false), "error: invalid CIGAR: `20SS'");
 	EXPECT_DEATH(SAMAlignment::parseCigar("20m", false), "error: invalid CIGAR: `20m'");
+}
+
+// Test friend std::istream& operator >>(std::istream& in, SAMRecord& o)
+TEST(parseSAMInput, check_values)
+{
+	std::string testSAMString("1:497:R:-272+13M17D24M	113	1	497	37	37M	15	100338662	0	CGGGTCTGACCTGAGGAGAACTGTGCTCCGCCTTCAG	0;==-==9;>>>>>=>>>>>>>>>>>=>>>>>>>>>>	XT:A:U	NM:i:0	SM:i:37	AM:i:0	X0:i:1	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37\n19:20389:F:275+18M2D19M	99	1	17644	0	37M	=	17919	314	TATGACTGCTAATAATACCTACACATGTTAGAACCAT	>>>>>>>>>>>>>>>>>>>><<>>><<>>4::>>:<9	RG:Z:UM0098:1	XT:A:R	NM:i:0	SM:i:0	AM:i:0	X0:i:4	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37");
+	std::istringstream testSAMIStringStream(testSAMString);
+	SAMRecord testSAMRecord;
+	testSAMIStringStream >> testSAMRecord;
+	EXPECT_EQ("1:497:R:-272+13M17D24M", testSAMRecord.qname);
+	EXPECT_EQ(113, testSAMRecord.flag);
+	EXPECT_EQ("1", testSAMRecord.rname);
+	EXPECT_EQ(496, testSAMRecord.pos);
+	EXPECT_EQ(37, testSAMRecord.mapq);
+	EXPECT_EQ("37M", testSAMRecord.cigar);
+	EXPECT_EQ("15", testSAMRecord.mrnm);
+	EXPECT_EQ(100338661, testSAMRecord.mpos);
+	EXPECT_EQ(0, testSAMRecord.isize);
+#if SAM_SEQ_QUAL
+	EXPECT_EQ("CGGGTCTGACCTGAGGAGAACTGTGCTCCGCCTTCAG", testSAMRecord.seq);
+	EXPECT_EQ("0;==-==9;>>>>>=>>>>>>>>>>>=>>>>>>>>>>", testSAMRecord.qual);
+	EXPECT_EQ("XT:A:U	NM:i:0	SM:i:37	AM:i:0	X0:i:1	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37", testSAMRecord.tags);
+#endif
+	testSAMIStringStream >> testSAMRecord;
+	EXPECT_EQ("19:20389:F:275+18M2D19M", testSAMRecord.qname);
+	EXPECT_EQ(99, testSAMRecord.flag);
+	EXPECT_EQ("1", testSAMRecord.rname);
+	EXPECT_EQ(17643, testSAMRecord.pos);
+	EXPECT_EQ(0, testSAMRecord.mapq);
+	EXPECT_EQ("37M", testSAMRecord.cigar);
+	EXPECT_EQ("1", testSAMRecord.mrnm);
+	EXPECT_EQ(17918, testSAMRecord.mpos);
+	EXPECT_EQ(314, testSAMRecord.isize);
+#if SAM_SEQ_QUAL
+	EXPECT_EQ("TATGACTGCTAATAATACCTACACATGTTAGAACCAT", testSAMRecord.seq);
+	EXPECT_EQ(">>>>>>>>>>>>>>>>>>>><<>>><<>>4::>>:<9", testSAMRecord.qual);
+	EXPECT_EQ("RG:Z:UM0098:1	XT:A:R	NM:i:0	SM:i:0	AM:i:0	X0:i:4	X1:i:0	XM:i:0	XO:i:0	XG:i:0	MD:Z:37", testSAMRecord.tags);
+#endif
+	
 }

--- a/Unittest/Makefile.am
+++ b/Unittest/Makefile.am
@@ -40,6 +40,11 @@ check_PROGRAMS += common_sam
 common_sam_SOURCES = Common/SAM.cc
 common_sam_LDADD = $(top_builddir)/Common/libcommon.a $(LDADD)
 
+check_PROGRAMS += common_sam_ssq
+common_sam_ssq_CPPFLAGS = $(AM_CPPFLAGS) $(common_sam_CPPFLAGS) -DSAM_SEQ_QUAL
+common_sam_ssq_LDADD = $(common_sam_LDADD)
+common_sam_ssq_SOURCES = $(common_sam_SOURCES)
+
 check_PROGRAMS += BloomFilter
 BloomFilter_SOURCES = Konnector/BloomFilter.cc
 BloomFilter_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/Common


### PR DESCRIPTION
SAMtools does not set the proper pair flag if the reads are mapped and oriented correctly. We need this flag to be set for tool development. abyss-fixmate does set the proper pair flag if the reads are mapped and oriented correctly so we've decided to use abyss-fixmate but abyss-fixmate does not capture all tags.

This PR contains changes so that all tags are captured.