### PR TITLE
Fix link to macOS install in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Contents
 
 * [Quick Start](#quick-start)
 	* [Install ABySS on Debian or Ubuntu](#install-abyss-on-debian-or-ubuntu)
-	* [Install ABySS on Mac OS X](#install-abyss-on-mac-os-x)
+	* [Install ABySS on macOS](#install-abyss-on-macos)
 * [Dependencies](#dependencies)
 * [Compiling ABySS from GitHub](#compiling-abyss-from-github)
 * [Compiling ABySS from source](#compiling-abyss-from-source)


### PR DESCRIPTION
Confirmed that the rest of the Table of Contents is up-to-date