### PR TITLE
Sealer: seal lower case iupac if option is specified

### DIFF
--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -716,7 +716,7 @@ void findFlanks(FastaRecord &record,
 	const string& seq = record.seq;
 	std::string gap = "Nn";
 	if (lower) {
-		gap = "Nnatcgurykmswbdhvnx";
+		gap = "Nnatcgurykmswbdhvx";
 	}
 
 	// Iterate over the gaps.

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -228,7 +228,7 @@ namespace opt {
 	/** Output detailed stats */
 	static int detailedStats = 0;
 
-	/** Seal lower case iupac */
+	/** Seal sequences with atcgurykmswbdhvx chars */
 	bool lower = false;
 }
 

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -112,7 +112,7 @@ static const char USAGE_MESSAGE[] =
 "  -g, --gap-file=FILE          write sealed gaps to FILE\n"
 "  -t, --trace-file=FILE        write graph search stats to FILE\n"
 "  -v, --verbose                display verbose output\n"
-"      --lower                  seal sequences with atcgurykmswbdhvx chars\n"
+"      --lower                  seal sequences with lower-case IUPAC characters\n"
 "      --help                   display this help and exit\n"
 "      --version                output version information and exit\n"
 "\n"

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -112,6 +112,7 @@ static const char USAGE_MESSAGE[] =
 "  -g, --gap-file=FILE          write sealed gaps to FILE\n"
 "  -t, --trace-file=FILE        write graph search stats to FILE\n"
 "  -v, --verbose                display verbose output\n"
+"      --lower                  seal sequences with atcgurykmswbdhvx chars\n"
 "      --help                   display this help and exit\n"
 "      --version                output version information and exit\n"
 "\n"

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -727,7 +727,7 @@ void findFlanks(FastaRecord &record,
 
 		size_t endposition = seq.string::find_first_not_of(gap, startposition);
 		if (endposition == string::npos) {
-			std::cerr << PROGRAM ": Warning: sequence ends with an N: " << record.id << "\n";
+			std::cerr << PROGRAM ": Warning: sequence ends with an " << gap << ": " << record.id << "\n";
 			break;
 		}
 

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -983,7 +983,7 @@ int main(int argc, char** argv)
 		opt::trimMasked = 0;
 	}
 
-	FastaReader reader1(scaffoldInputPath, flag);
+	FastaReader reader1(scaffoldInputPath, case_flag);
 	unsigned gapsfound = 0;
 	string temp;
 

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -710,14 +710,10 @@ bool operator<(const FastaRecord& a, const FastaRecord& b)
 void findFlanks(FastaRecord &record,
 	int flanklength,
 	unsigned &gapnumber,
-	map<FastaRecord, map<FastaRecord, Gap> > &flanks,
-	bool lower)
+	map<FastaRecord, map<FastaRecord, Gap> > &flanks)
 {
 	const string& seq = record.seq;
-	std::string gap = "Nn";
-	if (lower) {
-		gap = "Nnatcgurykmswbdhvx";
-	}
+	const std::string gap(opt::lower ? "Nnatcgurykmswbdhvx" : "Nn");
 
 	// Iterate over the gaps.
 	for (size_t offset = 0;
@@ -994,7 +990,7 @@ int main(int argc, char** argv)
 #pragma omp critical(reader1)
 		good = reader1 >> record;
 		if (good) {
-			findFlanks(record, opt::flankLength, gapsfound, flanks, opt::lower);
+			findFlanks(record, opt::flankLength, gapsfound, flanks);
 		}
 		else {
 			break;

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -251,9 +251,9 @@ struct Counters {
 	size_t skipped;
 };
 
-static const char shortopts[] = "S:L:b:B:C:d:ef:F:G:g:i:Ij:k:lm:M:no:P:q:r:s:t:vX";
+static const char shortopts[] = "S:L:b:B:C:d:ef:F:G:g:i:Ij:k:lm:M:no:P:q:r:s:t:v";
 
-enum { OPT_HELP = 1, OPT_VERSION };
+enum { OPT_HELP = 1, OPT_VERSION, OPT_LOWER };
 
 static const struct option longopts[] = {
 	{ "detailed-stats",   no_argument, &opt::detailedStats, 1},
@@ -291,7 +291,7 @@ static const struct option longopts[] = {
 	{ "trace-file",       required_argument, NULL, 't' },
 	{ "gap-file",         required_argument, NULL, 'g' },
 	{ "verbose",          no_argument, NULL, 'v' },
-	{ "lower",            no_argument, NULL, 'X' },
+	{ "lower",            no_argument, NULL, OPT_LOWER },
 	{ "help",             no_argument, NULL, OPT_HELP },
 	{ "version",          no_argument, NULL, OPT_VERSION },
 	{ NULL, 0, NULL, 0 }
@@ -801,8 +801,6 @@ int main(int argc, char** argv)
 			opt::k = tempK;
 			break;
 			}
-		  case 'X':
-			opt::lower = true; break;
 		  case 'm':
 			setMaxOption(opt::maxFlankMismatches, arg); break;
 		  case 'n':
@@ -829,6 +827,8 @@ int main(int argc, char** argv)
 		    arg >> opt::gapfilePath; break;
 		  case 'v':
 			opt::verbose++; break;
+		  case OPT_LOWER:
+			opt::lower = true; break;
 		  case OPT_HELP:
 			cout << USAGE_MESSAGE;
 			exit(EXIT_SUCCESS);

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -1100,8 +1100,14 @@ int main(int argc, char** argv)
 
 	map<string, map<int, map<string, string> > >::iterator scaf_it;
 	map<int, map<string, string> >::reverse_iterator pos_it;
-	FastaReader reader2(scaffoldInputPath, FastaReader::FOLD_CASE);
-	unsigned gapsclosedfinal = 0;
+
+	auto case_flag = FastaReader::FOLD_CASE;
+	if (opt::lower) {
+		case_flag = FastaReader::NO_FOLD_CASE;
+		opt::trimMasked = 0;
+	}
+	FastaReader reader2(scaffoldInputPath, case_flag);
+	unsigned gapsclosedfinal = 0;	
 
 	/** creating new scaffold with gaps closed */
 	for (FastaRecord record;;) {

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -974,7 +974,7 @@ int main(int argc, char** argv)
 	map<FastaRecord, map<FastaRecord, Gap> > flanks;
 	const char* scaffoldInputPath = opt::inputScaffold.c_str();
 
-	const auto case_flag = FastaReader::FOLD_CASE;
+	auto case_flag = FastaReader::FOLD_CASE;
 	if (opt::lower) {
 		case_flag = FastaReader::NO_FOLD_CASE;
 		opt::trimMasked = 0;

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -976,7 +976,14 @@ int main(int argc, char** argv)
 
 	map<FastaRecord, map<FastaRecord, Gap> > flanks;
 	const char* scaffoldInputPath = opt::inputScaffold.c_str();
-	FastaReader reader1(scaffoldInputPath, FastaReader::NO_FOLD_CASE);
+
+	auto case_flag = FastaReader::FOLD_CASE;
+	if (opt::lower) {
+		case_flag = FastaReader::NO_FOLD_CASE;
+		opt::trimMasked = 0;
+	}
+
+	FastaReader reader1(scaffoldInputPath, flag);
 	unsigned gapsfound = 0;
 	string temp;
 
@@ -1101,11 +1108,6 @@ int main(int argc, char** argv)
 	map<string, map<int, map<string, string> > >::iterator scaf_it;
 	map<int, map<string, string> >::reverse_iterator pos_it;
 
-	auto case_flag = FastaReader::FOLD_CASE;
-	if (opt::lower) {
-		case_flag = FastaReader::NO_FOLD_CASE;
-		opt::trimMasked = 0;
-	}
 	FastaReader reader2(scaffoldInputPath, case_flag);
 	unsigned gapsclosedfinal = 0;	
 

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -228,7 +228,7 @@ namespace opt {
 	/** Output detailed stats */
 	static int detailedStats = 0;
 
-	/** Seal sequences with atcgurykmswbdhvx chars */
+	/** Seal sequences with lower-case IUPAC characterss */
 	bool lower = false;
 }
 

--- a/Sealer/sealer.cc
+++ b/Sealer/sealer.cc
@@ -974,7 +974,7 @@ int main(int argc, char** argv)
 	map<FastaRecord, map<FastaRecord, Gap> > flanks;
 	const char* scaffoldInputPath = opt::inputScaffold.c_str();
 
-	auto case_flag = FastaReader::FOLD_CASE;
+	const auto case_flag = FastaReader::FOLD_CASE;
 	if (opt::lower) {
 		case_flag = FastaReader::NO_FOLD_CASE;
 		opt::trimMasked = 0;


### PR DESCRIPTION
This pull request contains the features requested by Rene in order for it to be compatible with the new ntEdit + Sealer protocol. The idea is to seal softmasked regions using Sealer. To do this, we need to find flanks surrounding lower case iupac characters in addition to N/n. To turn this feature on, the user can specify "--lower".