### PR TITLE
Fix build failure on macOS 12 and 13

### DIFF
--- a/Assembly/Makefile.am
+++ b/Assembly/Makefile.am
@@ -22,4 +22,4 @@ libassembly_a_SOURCES = \
 	SplitAlgorithm.h \
 	TrimAlgorithm.h
 
-libassembly_a_LIBADD = $(wildcard $(top_srcdir)/Common/*.o)
+libassembly_a_LIBADD = $(wildcard $(top_builddir)/Common/*.o)

--- a/Assembly/Makefile.am
+++ b/Assembly/Makefile.am
@@ -22,4 +22,4 @@ libassembly_a_SOURCES = \
 	SplitAlgorithm.h \
 	TrimAlgorithm.h
 
-libassembly_a_LIBADD = $(top_builddir)/Common/libcommon.a
+libassembly_a_LIBADD = $(wildcard $(top_srcdir)/Common/*.o)

--- a/DataBase/Makefile.am
+++ b/DataBase/Makefile.am
@@ -1,7 +1,7 @@
 noinst_LIBRARIES = libdb.a
 libdb_a_SOURCES = DB.cc DB.h Options.h
 libdb_a_CPPFLAGS = -I$(top_srcdir)
-libdb_a_LIBADD = $(wildcard $(top_srcdir)/Common/*.o)
+libdb_a_LIBADD = $(wildcard $(top_builddir)/Common/*.o)
 
 if HAVE_SQLITE3
 bin_PROGRAMS = abyss-db-csv

--- a/DataBase/Makefile.am
+++ b/DataBase/Makefile.am
@@ -1,7 +1,7 @@
 noinst_LIBRARIES = libdb.a
 libdb_a_SOURCES = DB.cc DB.h Options.h
 libdb_a_CPPFLAGS = -I$(top_srcdir)
-libdb_a_LIBADD = $(top_builddir)/Common/libcommon.a
+libdb_a_LIBADD = $(wildcard $(top_srcdir)/Common/*.o)
 
 if HAVE_SQLITE3
 bin_PROGRAMS = abyss-db-csv

--- a/RResolver/Makefile.am
+++ b/RResolver/Makefile.am
@@ -31,6 +31,6 @@ libralgorithmsshort_a_SOURCES = \
 	RUtils.cpp RUtils.h
 
 libralgorithmsshort_a_LIBADD = \
-	$(top_builddir)/DataLayer/libdatalayer.a \
-	$(top_builddir)/Common/libcommon.a
+	$(wildcard $(top_srcdir)/DataLayer/*.o) \
+	$(wildcard $(top_srcdir)/Common/*.o)
 

--- a/RResolver/Makefile.am
+++ b/RResolver/Makefile.am
@@ -31,6 +31,6 @@ libralgorithmsshort_a_SOURCES = \
 	RUtils.cpp RUtils.h
 
 libralgorithmsshort_a_LIBADD = \
-	$(wildcard $(top_srcdir)/DataLayer/*.o) \
-	$(wildcard $(top_srcdir)/Common/*.o)
+	$(wildcard $(top_builddir)/DataLayer/*.o) \
+	$(wildcard $(top_builddir)/Common/*.o)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 jobs:  
-- job: mac_gcc
+- job: mac11_gcc
   pool:
     vmImage: macOS-11
   steps:
@@ -18,6 +18,35 @@ jobs:
     displayName: Install btllib
   - script: |
       ./autogen.sh
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-12 CXX=g++-12 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.1/install"
+      ./configure CC=gcc-12 CXX=g++-12 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.1/install
+      make -j12 distcheck
+    displayName: Compiling ABySS with gcc-12
+
+- job: mac_latest_gcc
+  pool:
+    vmImage: macOS-latest
+  steps:
+  - script: |
+      rm -f /usr/local/bin/2to3 # brew is having issues with installing Python
+      brew update
+      brew install automake boost openmpi google-sparsehash make pandoc ghc gcc@12 llvm
+    displayName: Install common
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.5.1/btllib-1.5.1.tar.gz
+      export CC=gcc-12
+      export CXX=g++-12
+      tar xzf btllib-1.5.1.tar.gz
+      cd btllib-1.5.1
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export CXXFLAGS="$CXXFLAGS -fuse-ld=lld"
+      echo $CXXFLAGS
+      export CFLAGS="$CFLAGS -fuse-ld=lld"
+      export OBJCFLAGS="$OBJCFLAGS -fuse-ld=lld"
+      export OBJCXXFLAGS="$OBJCXXFLAGS -fuse-ld=lld"
       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-12 CXX=g++-12 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.1/install"
       ./configure CC=gcc-12 CXX=g++-12 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.1/install
       make -j12 distcheck

--- a/vendor/gtest-1.7.0/Makefile.am
+++ b/vendor/gtest-1.7.0/Makefile.am
@@ -34,9 +34,9 @@ EXTRA_DIST = \
   include/gtest/internal/gtest-type-util.h
 
 libgtest_a_CPPFLAGS = -I$(top_srcdir) -isystem $(top_srcdir)/vendor/gtest-1.7.0/include
-libgtest_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-error=unused-result
+libgtest_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-maybe-uninitialized -Wno-error=unused-result
 libgtest_a_SOURCES = src/gtest-all.cc
 
 libgtest_main_a_CPPFLAGS = -I$(top_srcdir) -isystem $(top_srcdir)/vendor/gtest-1.7.0/include
-libgtest_main_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-error=unused-result
+libgtest_main_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-maybe-uninitialized -Wno-error=unused-result
 libgtest_main_a_SOURCES = src/gtest_main.cc src/gtest-all.cc

--- a/vendor/gtest-1.7.0/Makefile.am
+++ b/vendor/gtest-1.7.0/Makefile.am
@@ -34,9 +34,9 @@ EXTRA_DIST = \
   include/gtest/internal/gtest-type-util.h
 
 libgtest_a_CPPFLAGS = -I$(top_srcdir) -isystem $(top_srcdir)/vendor/gtest-1.7.0/include
-libgtest_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-maybe-uninitialized -Wno-error=unused-result
+libgtest_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-uninitialized -Wno-error=unused-result
 libgtest_a_SOURCES = src/gtest-all.cc
 
 libgtest_main_a_CPPFLAGS = -I$(top_srcdir) -isystem $(top_srcdir)/vendor/gtest-1.7.0/include
-libgtest_main_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-maybe-uninitialized -Wno-error=unused-result
+libgtest_main_a_CXXFLAGS = $(AM_CXXFLAGS) -Wno-missing-field-initializers -Wno-uninitialized -Wno-error=unused-result
 libgtest_main_a_SOURCES = src/gtest_main.cc src/gtest-all.cc


### PR DESCRIPTION
Addresses #466

- Replaced linking to other `.a` files in libraries with lists of `.o` files.
- Re-added compiling with GCC-12 on macOS-latest to CI.