### PR TITLE
CI fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,116 +1,116 @@
 jobs:  
-- job: mac_latest_gcc
-  pool:
-    vmImage: macOS-latest
-  steps:
-  - script: |
-      find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete  # Trying solution from https://github.com/mesonbuild/meson/blob/master/.github/workflows/macos.yml#L87-L92
-      sudo rm -rf /Library/Frameworks/Python.framework/
-      brew install --force python3 node@18 && brew unlink python3 node@18 && brew unlink python3 node@18 && brew link --overwrite python3 node@18
-      find /usr/local/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
-      brew update
-      brew install automake boost openmpi google-sparsehash make pandoc ghc gcc@14 llvm
-    displayName: Install common
-  - script: |
-      wget https://github.com/bcgsc/btllib/releases/download/v1.5.0/btllib-1.5.0.tar.gz
-      export CC=gcc-14
-      export CXX=g++-14
-      tar xzf btllib-1.5.0.tar.gz
-      cd btllib-1.5.0
-      ./compile
-    displayName: Install btllib
-  - script: |
-      ./autogen.sh
-      export CC=gcc-14
-      export CXX=g++-14
-      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install"
-      ./configure CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install
-      make -j12 distcheck AM_CXXFLAGS=-Wno-error=dangling-reference
-    displayName: Compiling ABySS with gcc-14
+# - job: mac_latest_gcc
+#   pool:
+#     vmImage: macOS-latest
+#   steps:
+#   - script: |
+#       find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete  # Trying solution from https://github.com/mesonbuild/meson/blob/master/.github/workflows/macos.yml#L87-L92
+#       sudo rm -rf /Library/Frameworks/Python.framework/
+#       brew install --force python3 node@18 && brew unlink python3 node@18 && brew unlink python3 node@18 && brew link --overwrite python3 node@18
+#       find /usr/local/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+#       brew update
+#       brew install automake boost openmpi google-sparsehash make pandoc ghc gcc@14 llvm
+#     displayName: Install common
+#   - script: |
+#       wget https://github.com/bcgsc/btllib/releases/download/v1.5.0/btllib-1.5.0.tar.gz
+#       export CC=gcc-14
+#       export CXX=g++-14
+#       tar xzf btllib-1.5.0.tar.gz
+#       cd btllib-1.5.0
+#       ./compile
+#     displayName: Install btllib
+#   - script: |
+#       ./autogen.sh
+#       export CC=gcc-14
+#       export CXX=g++-14
+#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install"
+#       ./configure CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install
+#       make -j12 distcheck AM_CXXFLAGS=-Wno-error=dangling-reference
+#     displayName: Compiling ABySS with gcc-14
 
-- job:
-  displayName: mac_latest-compilers-clang
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-  - script: |
-      mkdir -p ~/miniforge3
-      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-      rm -rf  ~/miniforge3/miniforge.sh
-      ~/miniforge3/bin/conda init bash
-      ~/miniforge3/bin/conda init zsh
-      export CONDA=$(realpath ~/miniforge3/bin)
-      echo "##vso[task.prependpath]$CONDA"
-    displayName: Install conda
-  - script: conda create --yes --quiet --name abyss_CI
-    displayName: Create Anaconda environment
-  - script: |
-      source activate abyss_CI
-      mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi automake perl pandoc meson ninja btllib
-    displayName: Install dependencies
-  - script: |
-      source activate abyss_CI
-      ./autogen.sh
-      ./configure
-      make -j12 distcheck AM_CXXFLAGS=-Wno-error=unused-but-set-variable
-    displayName: Compiling ABySS
+# - job:
+#   displayName: mac_latest-compilers-clang
+#   pool:
+#     vmImage: 'macOS-latest'
+#   steps:
+#   - script: |
+#       mkdir -p ~/miniforge3
+#       curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+#       bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+#       rm -rf  ~/miniforge3/miniforge.sh
+#       ~/miniforge3/bin/conda init bash
+#       ~/miniforge3/bin/conda init zsh
+#       export CONDA=$(realpath ~/miniforge3/bin)
+#       echo "##vso[task.prependpath]$CONDA"
+#     displayName: Install conda
+#   - script: conda create --yes --quiet --name abyss_CI
+#     displayName: Create Anaconda environment
+#   - script: |
+#       source activate abyss_CI
+#       mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi automake perl pandoc meson ninja btllib
+#     displayName: Install dependencies
+#   - script: |
+#       source activate abyss_CI
+#       ./autogen.sh
+#       ./configure
+#       make -j12 distcheck AM_CXXFLAGS=-Wno-error=unused-but-set-variable
+#     displayName: Compiling ABySS
 
-- job:
-  displayName: mac_clang14
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-  - script: |
-      mkdir -p ~/miniforge3
-      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-      rm -rf  ~/miniforge3/miniforge.sh
-      ~/miniforge3/bin/conda init bash
-      ~/miniforge3/bin/conda init zsh
-      export CONDA=$(realpath ~/miniforge3/bin)
-      echo "##vso[task.prependpath]$CONDA"
-    displayName: Install conda
-  - script: conda create --yes --quiet --name abyss_CI
-    displayName: Create Anaconda environment
-  - script: |
-      source activate abyss_CI
-      mamba install --yes -c conda-forge -c bioconda compilers=1.5.2 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
-    displayName: Install dependencies
-  - script: |
-      source activate abyss_CI
-      ./autogen.sh
-      ./configure
-      make -j12 distcheck
-    displayName: Compiling ABySS
+# - job:
+#   displayName: mac_clang14
+#   pool:
+#     vmImage: 'macOS-latest'
+#   steps:
+#   - script: |
+#       mkdir -p ~/miniforge3
+#       curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+#       bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+#       rm -rf  ~/miniforge3/miniforge.sh
+#       ~/miniforge3/bin/conda init bash
+#       ~/miniforge3/bin/conda init zsh
+#       export CONDA=$(realpath ~/miniforge3/bin)
+#       echo "##vso[task.prependpath]$CONDA"
+#     displayName: Install conda
+#   - script: conda create --yes --quiet --name abyss_CI
+#     displayName: Create Anaconda environment
+#   - script: |
+#       source activate abyss_CI
+#       mamba install --yes -c conda-forge -c bioconda compilers=1.5.2 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+#     displayName: Install dependencies
+#   - script: |
+#       source activate abyss_CI
+#       ./autogen.sh
+#       ./configure
+#       make -j12 distcheck
+#     displayName: Compiling ABySS
 
-- job:
-  displayName: mac_clang13
-  pool:
-    vmImage: 'macOS-latest'
-  steps:
-  - script: |
-      mkdir -p ~/miniforge3
-      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-      rm -rf  ~/miniforge3/miniforge.sh
-      ~/miniforge3/bin/conda init bash
-      ~/miniforge3/bin/conda init zsh
-      export CONDA=$(realpath ~/miniforge3/bin)
-      echo "##vso[task.prependpath]$CONDA"
-    displayName: Install conda
-  - script: conda create --yes --quiet --name abyss_CI
-    displayName: Create Anaconda environment
-  - script: |
-      source activate abyss_CI
-      mamba install --yes -c conda-forge -c bioconda compilers=1.4.2 make boost-cpp sparsehash openmpi automake perl btllib pandoc 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
-    displayName: Install dependencies
-  - script: |
-      source activate abyss_CI
-      ./autogen.sh
-      ./configure
-      make -j12 distcheck
-    displayName: Compiling ABySS with clang 13
+# - job:
+#   displayName: mac_clang13
+#   pool:
+#     vmImage: 'macOS-latest'
+#   steps:
+#   - script: |
+#       mkdir -p ~/miniforge3
+#       curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+#       bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+#       rm -rf  ~/miniforge3/miniforge.sh
+#       ~/miniforge3/bin/conda init bash
+#       ~/miniforge3/bin/conda init zsh
+#       export CONDA=$(realpath ~/miniforge3/bin)
+#       echo "##vso[task.prependpath]$CONDA"
+#     displayName: Install conda
+#   - script: conda create --yes --quiet --name abyss_CI
+#     displayName: Create Anaconda environment
+#   - script: |
+#       source activate abyss_CI
+#       mamba install --yes -c conda-forge -c bioconda compilers=1.4.2 make boost-cpp sparsehash openmpi automake perl btllib pandoc 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+#     displayName: Install dependencies
+#   - script: |
+#       source activate abyss_CI
+#       ./autogen.sh
+#       ./configure
+#       make -j12 distcheck
+#     displayName: Compiling ABySS with clang 13
 
 - job:
   displayName: mac_clang12
@@ -131,188 +131,189 @@ jobs:
     displayName: Create Anaconda environment
   - script: |
       source activate abyss_CI
-      mamba install --yes -c conda-forge -c bioconda compilers=1.4.0 make boost-cpp sparsehash openmpi automake perl pandoc llvm-openmp btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+      conda install --yes -c conda-forge -c bioconda compilers=1.4.0 make boost-cpp sparsehash openmpi automake perl pandoc llvm-openmp btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
     displayName: Install dependencies
   - script: |
       source activate abyss_CI
+      echo $CXXFLAGS
       ./autogen.sh
       ./configure
       make -j12 distcheck
     displayName: Compiling ABySS with clang 12
 
 
-- job: linux_gcc12
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - script: |
-      sudo apt-get update -qq
-      sudo apt-get install -qq software-properties-common
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-      sudo apt-get update -qq
-      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-    displayName: Install common
-  - script: sudo apt-get install -qq gcc-12 g++-12
-    displayName: Install gcc-12
-  - script: |
-      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-      tar xzf btllib-1.7.2.tar.gz
-      cd btllib-1.7.2
-      export CC=gcc-12
-      export CXX=g++-12
-      ./compile
-    displayName: Install btllib
-  - script: |
-      ./autogen.sh
-      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-12 CXX=g++-12 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-      ./configure CC=gcc-12 CXX=g++-12 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-      make -j12 distcheck
-    displayName: Compiling ABySS with gcc-12
+# - job: linux_gcc12
+#   pool:
+#     vmImage: ubuntu-latest
+#   steps:
+#   - script: |
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq software-properties-common
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+#     displayName: Install common
+#   - script: sudo apt-get install -qq gcc-12 g++-12
+#     displayName: Install gcc-12
+#   - script: |
+#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+#       tar xzf btllib-1.7.2.tar.gz
+#       cd btllib-1.7.2
+#       export CC=gcc-12
+#       export CXX=g++-12
+#       ./compile
+#     displayName: Install btllib
+#   - script: |
+#       ./autogen.sh
+#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-12 CXX=g++-12 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+#       ./configure CC=gcc-12 CXX=g++-12 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+#       make -j12 distcheck
+#     displayName: Compiling ABySS with gcc-12
 
 
-- job: linux_gcc11
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - script: |
-      sudo apt-get update -qq
-      sudo apt-get install -qq software-properties-common
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-      sudo apt-get update -qq
-      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-    displayName: Install common
-  - script: sudo apt-get install -qq gcc-11 g++-11
-    displayName: Install gcc-11
-  - script: |
-      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-      tar xzf btllib-1.7.2.tar.gz
-      cd btllib-1.7.2
-      export CC=gcc-11
-      export CXX=g++-11
-      ./compile
-    displayName: Install btllib
-  - script: |
-      ./autogen.sh
-      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-11 CXX=g++-11 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-      ./configure CC=gcc-11 CXX=g++-11 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-      make -j12 distcheck
-    displayName: Compiling ABySS with gcc-11
+# - job: linux_gcc11
+#   pool:
+#     vmImage: ubuntu-latest
+#   steps:
+#   - script: |
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq software-properties-common
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+#     displayName: Install common
+#   - script: sudo apt-get install -qq gcc-11 g++-11
+#     displayName: Install gcc-11
+#   - script: |
+#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+#       tar xzf btllib-1.7.2.tar.gz
+#       cd btllib-1.7.2
+#       export CC=gcc-11
+#       export CXX=g++-11
+#       ./compile
+#     displayName: Install btllib
+#   - script: |
+#       ./autogen.sh
+#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-11 CXX=g++-11 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+#       ./configure CC=gcc-11 CXX=g++-11 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+#       make -j12 distcheck
+#     displayName: Compiling ABySS with gcc-11
 
-- job: linux_gcc10
-  pool:
-    vmImage: ubuntu-20.04
-  steps:
-  - script: |
-      sudo apt-get update -qq
-      sudo apt-get install -qq software-properties-common
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-      sudo apt-get update -qq
-      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-    displayName: Install common
-  - script: sudo apt-get install -qq gcc-10 g++-10
-    displayName: Install gcc-10
-  - script: |
-      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-      tar xzf btllib-1.7.2.tar.gz
-      cd btllib-1.7.2
-      export CC=gcc-10
-      export CXX=g++-10
-      ./compile
-    displayName: Install btllib
-  - script: |
-      ./autogen.sh
-      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-10 CXX=g++-10 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-      ./configure CC=gcc-10 CXX=g++-10 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-      make -j12 distcheck
-    displayName: Compiling ABySS with gcc-10
-  - script: |
-      curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
-      sudo apt-get update
-      sudo apt-get install -y --no-install-recommends clang-format-8
-      sudo ln -sf clang-format-8 /usr/bin/clang-format
-    displayName: Install clang-format
-  - script: make clang-format
-    displayName: Run clang-format
+# - job: linux_gcc10
+#   pool:
+#     vmImage: ubuntu-20.04
+#   steps:
+#   - script: |
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq software-properties-common
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+#     displayName: Install common
+#   - script: sudo apt-get install -qq gcc-10 g++-10
+#     displayName: Install gcc-10
+#   - script: |
+#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+#       tar xzf btllib-1.7.2.tar.gz
+#       cd btllib-1.7.2
+#       export CC=gcc-10
+#       export CXX=g++-10
+#       ./compile
+#     displayName: Install btllib
+#   - script: |
+#       ./autogen.sh
+#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-10 CXX=g++-10 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+#       ./configure CC=gcc-10 CXX=g++-10 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+#       make -j12 distcheck
+#     displayName: Compiling ABySS with gcc-10
+#   - script: |
+#       curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+#       sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+#       sudo apt-get update
+#       sudo apt-get install -y --no-install-recommends clang-format-8
+#       sudo ln -sf clang-format-8 /usr/bin/clang-format
+#     displayName: Install clang-format
+#   - script: make clang-format
+#     displayName: Run clang-format
 
-- job: linux_gcc9
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - script: |
-      sudo apt-get update -qq
-      sudo apt-get install -qq software-properties-common
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-      sudo apt-get update -qq
-      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-    displayName: Install common
-  - script: sudo apt-get install -qq gcc-9 g++-9
-    displayName: Install gcc-9
-  - script: |
-      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-      tar xzf btllib-1.7.2.tar.gz
-      cd btllib-1.7.2
-      export CC=gcc-9
-      export CXX=g++-9
-      ./compile
-    displayName: Install btllib
-  - script: |
-      ./autogen.sh
-      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-9 CXX=g++-9 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-      ./configure CC=gcc-9 CXX=g++-9 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-      make -j12 distcheck
-    displayName: Compiling ABySS with gcc-9
+# - job: linux_gcc9
+#   pool:
+#     vmImage: ubuntu-latest
+#   steps:
+#   - script: |
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq software-properties-common
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+#     displayName: Install common
+#   - script: sudo apt-get install -qq gcc-9 g++-9
+#     displayName: Install gcc-9
+#   - script: |
+#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+#       tar xzf btllib-1.7.2.tar.gz
+#       cd btllib-1.7.2
+#       export CC=gcc-9
+#       export CXX=g++-9
+#       ./compile
+#     displayName: Install btllib
+#   - script: |
+#       ./autogen.sh
+#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-9 CXX=g++-9 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+#       ./configure CC=gcc-9 CXX=g++-9 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+#       make -j12 distcheck
+#     displayName: Compiling ABySS with gcc-9
 
-- job: linux_gcc8
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - script: |
-      sudo apt-get update -qq
-      sudo apt-get install -qq software-properties-common
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal main universe security"
-      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal-updates main universe restricted"
-      sudo apt-get update -qq
-      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-    displayName: Install common
-  - script: sudo apt-get install -qq gcc-8 g++-8
-    displayName: Install gcc-8
-  - script: |
-      wget https://github.com/bcgsc/btllib/releases/download/v1.6.0/btllib-1.6.0.tar.gz
-      tar xzf btllib-1.6.0.tar.gz
-      cd btllib-1.6.0
-      export CC=gcc-8
-      export CXX=g++-8
-      ./compile
-    displayName: Install btllib
-  - script: |
-      ./autogen.sh
-      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-8 CXX=g++-8 --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install"
-      ./configure CC=gcc-8 CXX=g++-8 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install
-      make -j12 distcheck
-    displayName: Compiling ABySS with gcc-8
+# - job: linux_gcc8
+#   pool:
+#     vmImage: ubuntu-latest
+#   steps:
+#   - script: |
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq software-properties-common
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal main universe security"
+#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal-updates main universe restricted"
+#       sudo apt-get update -qq
+#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+#     displayName: Install common
+#   - script: sudo apt-get install -qq gcc-8 g++-8
+#     displayName: Install gcc-8
+#   - script: |
+#       wget https://github.com/bcgsc/btllib/releases/download/v1.6.0/btllib-1.6.0.tar.gz
+#       tar xzf btllib-1.6.0.tar.gz
+#       cd btllib-1.6.0
+#       export CC=gcc-8
+#       export CXX=g++-8
+#       ./compile
+#     displayName: Install btllib
+#   - script: |
+#       ./autogen.sh
+#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-8 CXX=g++-8 --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install"
+#       ./configure CC=gcc-8 CXX=g++-8 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install
+#       make -j12 distcheck
+#     displayName: Compiling ABySS with gcc-8
 
-- job:
-  displayName: linux_gcc-latest
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
-  - script: conda create --yes --quiet --name abyss_CI
-    displayName: Create Anaconda environment
-  - script: |
-      source activate abyss_CI
-      conda install --yes -c conda-forge mamba python=3.9
-      mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi util-linux perl btllib pandoc
-    displayName: Install dependencies
-  - script: |
-      source activate abyss_CI
-      ./autogen.sh
-      ./configure
-      make -j12 distcheck AM_CXXFLAGS=-Wall CXXFLAGS='-pthread'
-    displayName: Compiling ABySS with gcc
+# - job:
+#   displayName: linux_gcc-latest
+#   pool:
+#     vmImage: 'ubuntu-latest'
+#   steps:
+#   - script: echo "##vso[task.prependpath]$CONDA/bin"
+#     displayName: Add conda to PATH
+#   - script: conda create --yes --quiet --name abyss_CI
+#     displayName: Create Anaconda environment
+#   - script: |
+#       source activate abyss_CI
+#       conda install --yes -c conda-forge mamba python=3.9
+#       mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi util-linux perl btllib pandoc
+#     displayName: Install dependencies
+#   - script: |
+#       source activate abyss_CI
+#       ./autogen.sh
+#       ./configure
+#       make -j12 distcheck AM_CXXFLAGS=-Wall CXXFLAGS='-pthread'
+#     displayName: Compiling ABySS with gcc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,116 +1,172 @@
 jobs:  
-# - job: mac_latest_gcc
-#   pool:
-#     vmImage: macOS-latest
-#   steps:
-#   - script: |
-#       find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete  # Trying solution from https://github.com/mesonbuild/meson/blob/master/.github/workflows/macos.yml#L87-L92
-#       sudo rm -rf /Library/Frameworks/Python.framework/
-#       brew install --force python3 node@18 && brew unlink python3 node@18 && brew unlink python3 node@18 && brew link --overwrite python3 node@18
-#       find /usr/local/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
-#       brew update
-#       brew install automake boost openmpi google-sparsehash make pandoc ghc gcc@14 llvm
-#     displayName: Install common
-#   - script: |
-#       wget https://github.com/bcgsc/btllib/releases/download/v1.5.0/btllib-1.5.0.tar.gz
-#       export CC=gcc-14
-#       export CXX=g++-14
-#       tar xzf btllib-1.5.0.tar.gz
-#       cd btllib-1.5.0
-#       ./compile
-#     displayName: Install btllib
-#   - script: |
-#       ./autogen.sh
-#       export CC=gcc-14
-#       export CXX=g++-14
-#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install"
-#       ./configure CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install
-#       make -j12 distcheck AM_CXXFLAGS=-Wno-error=dangling-reference
-#     displayName: Compiling ABySS with gcc-14
+- job: mac_latest_gcc
+  pool:
+    vmImage: macOS-latest
+  steps:
+  - script: |
+      find /usr/local/bin -lname '*/Library/Frameworks/Python.framework/*' -delete  # Trying solution from https://github.com/mesonbuild/meson/blob/master/.github/workflows/macos.yml#L87-L92
+      sudo rm -rf /Library/Frameworks/Python.framework/
+      brew install --force python3 node@18 && brew unlink python3 node@18 && brew unlink python3 node@18 && brew link --overwrite python3 node@18
+      find /usr/local/Cellar/python* -name EXTERNALLY-MANAGED -print0 | xargs -0 rm -vf
+      brew update
+      brew install automake boost openmpi google-sparsehash make pandoc ghc gcc@14 llvm
+    displayName: Install common
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.5.0/btllib-1.5.0.tar.gz
+      export CC=gcc-14
+      export CXX=g++-14
+      tar xzf btllib-1.5.0.tar.gz
+      cd btllib-1.5.0
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export CC=gcc-14
+      export CXX=g++-14
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install"
+      ./configure CC=gcc-14 CXX=g++-14 --with-boost=/usr/local/opt/boost --with-sparsehash=/usr/local/opt/google-sparsehash --with-mpi=/usr/local/opt/openmpi --with-btllib=/Users/runner/work/1/s/btllib-1.5.0/install
+      make -j12 distcheck AM_CXXFLAGS=-Wno-error=dangling-reference
+    displayName: Compiling ABySS with gcc-14
 
-# - job:
-#   displayName: mac_latest-compilers-clang
-#   pool:
-#     vmImage: 'macOS-latest'
-#   steps:
-#   - script: |
-#       mkdir -p ~/miniforge3
-#       curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-#       bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-#       rm -rf  ~/miniforge3/miniforge.sh
-#       ~/miniforge3/bin/conda init bash
-#       ~/miniforge3/bin/conda init zsh
-#       export CONDA=$(realpath ~/miniforge3/bin)
-#       echo "##vso[task.prependpath]$CONDA"
-#     displayName: Install conda
-#   - script: conda create --yes --quiet --name abyss_CI
-#     displayName: Create Anaconda environment
-#   - script: |
-#       source activate abyss_CI
-#       mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi automake perl pandoc meson ninja btllib
-#     displayName: Install dependencies
-#   - script: |
-#       source activate abyss_CI
-#       ./autogen.sh
-#       ./configure
-#       make -j12 distcheck AM_CXXFLAGS=-Wno-error=unused-but-set-variable
-#     displayName: Compiling ABySS
+- job:
+  displayName: mac_latest-compilers-clang
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
+  - script: conda create --yes --quiet --name abyss_CI
+    displayName: Create Anaconda environment
+  - script: |
+      source activate abyss_CI
+      mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi automake perl pandoc meson ninja btllib
+    displayName: Install dependencies
+  - script: |
+      source activate abyss_CI
+      ./autogen.sh
+      ./configure
+      make -j12 distcheck AM_CXXFLAGS=-Wno-error=unused-but-set-variable
+    displayName: Compiling ABySS
 
-# - job:
-#   displayName: mac_clang14
-#   pool:
-#     vmImage: 'macOS-latest'
-#   steps:
-#   - script: |
-#       mkdir -p ~/miniforge3
-#       curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-#       bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-#       rm -rf  ~/miniforge3/miniforge.sh
-#       ~/miniforge3/bin/conda init bash
-#       ~/miniforge3/bin/conda init zsh
-#       export CONDA=$(realpath ~/miniforge3/bin)
-#       echo "##vso[task.prependpath]$CONDA"
-#     displayName: Install conda
-#   - script: conda create --yes --quiet --name abyss_CI
-#     displayName: Create Anaconda environment
-#   - script: |
-#       source activate abyss_CI
-#       mamba install --yes -c conda-forge -c bioconda compilers=1.5.2 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
-#     displayName: Install dependencies
-#   - script: |
-#       source activate abyss_CI
-#       ./autogen.sh
-#       ./configure
-#       make -j12 distcheck
-#     displayName: Compiling ABySS
+- job:
+  displayName: mac_clang16
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
+  - script: conda create --yes --quiet --name abyss_CI
+    displayName: Create Anaconda environment
+  - script: |
+      source activate abyss_CI
+      mamba install --yes -c conda-forge -c bioconda compilers=1.7.0 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+    displayName: Install dependencies
+  - script: |
+      source activate abyss_CI
+      ./autogen.sh
+      ./configure
+      make -j12 distcheck
+    displayName: Compiling ABySS
 
-# - job:
-#   displayName: mac_clang13
-#   pool:
-#     vmImage: 'macOS-latest'
-#   steps:
-#   - script: |
-#       mkdir -p ~/miniforge3
-#       curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-#       bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-#       rm -rf  ~/miniforge3/miniforge.sh
-#       ~/miniforge3/bin/conda init bash
-#       ~/miniforge3/bin/conda init zsh
-#       export CONDA=$(realpath ~/miniforge3/bin)
-#       echo "##vso[task.prependpath]$CONDA"
-#     displayName: Install conda
-#   - script: conda create --yes --quiet --name abyss_CI
-#     displayName: Create Anaconda environment
-#   - script: |
-#       source activate abyss_CI
-#       mamba install --yes -c conda-forge -c bioconda compilers=1.4.2 make boost-cpp sparsehash openmpi automake perl btllib pandoc 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
-#     displayName: Install dependencies
-#   - script: |
-#       source activate abyss_CI
-#       ./autogen.sh
-#       ./configure
-#       make -j12 distcheck
-#     displayName: Compiling ABySS with clang 13
+- job:
+  displayName: mac_clang15
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
+  - script: conda create --yes --quiet --name abyss_CI
+    displayName: Create Anaconda environment
+  - script: |
+      source activate abyss_CI
+      mamba install --yes -c conda-forge -c bioconda compilers=1.6.0 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+    displayName: Install dependencies
+  - script: |
+      source activate abyss_CI
+      ./autogen.sh
+      ./configure
+      make -j12 distcheck
+    displayName: Compiling ABySS
+
+- job:
+  displayName: mac_clang14
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
+  - script: conda create --yes --quiet --name abyss_CI
+    displayName: Create Anaconda environment
+  - script: |
+      source activate abyss_CI
+      mamba install --yes -c conda-forge -c bioconda compilers=1.5.2 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+    displayName: Install dependencies
+  - script: |
+      source activate abyss_CI
+      ./autogen.sh
+      ./configure
+      make -j12 distcheck
+    displayName: Compiling ABySS
+
+- job:
+  displayName: mac_clang13
+  pool:
+    vmImage: 'macOS-latest'
+  steps:
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
+  - script: conda create --yes --quiet --name abyss_CI
+    displayName: Create Anaconda environment
+  - script: |
+      source activate abyss_CI
+      mamba install --yes -c conda-forge -c bioconda compilers=1.4.2 make boost-cpp sparsehash openmpi automake perl btllib pandoc 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+    displayName: Install dependencies
+  - script: |
+      source activate abyss_CI
+      ./autogen.sh
+      ./configure
+      make -j12 distcheck
+    displayName: Compiling ABySS with clang 13
 
 - job:
   displayName: mac_clang12
@@ -136,6 +192,7 @@ jobs:
   - script: |
       source activate abyss_CI
       echo $CXXFLAGS
+      ls /Users/runner/miniforge3/envs/abyss_CI/include
       ./autogen.sh
       ./configure
       make -j12 distcheck

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,13 +33,20 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
   - script: conda create --yes --quiet --name abyss_CI
     displayName: Create Anaconda environment
   - script: |
       source activate abyss_CI
-      conda install --yes -c conda-forge mamba python=3.9
       mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi automake perl pandoc meson ninja btllib
     displayName: Install dependencies
   - script: |
@@ -54,13 +61,20 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
   - script: conda create --yes --quiet --name abyss_CI
     displayName: Create Anaconda environment
   - script: |
       source activate abyss_CI
-      conda install --yes -c conda-forge mamba python=3.9
       mamba install --yes -c conda-forge -c bioconda compilers=1.5.2 make boost-cpp sparsehash openmpi automake perl pandoc btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
     displayName: Install dependencies
   - script: |
@@ -75,13 +89,20 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
   - script: conda create --yes --quiet --name abyss_CI
     displayName: Create Anaconda environment
   - script: |
       source activate abyss_CI
-      conda install --yes -c conda-forge mamba python=3.9
       mamba install --yes -c conda-forge -c bioconda compilers=1.4.2 make boost-cpp sparsehash openmpi automake perl btllib pandoc 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
     displayName: Install dependencies
   - script: |
@@ -96,13 +117,20 @@ jobs:
   pool:
     vmImage: 'macOS-latest'
   steps:
-  - script: echo "##vso[task.prependpath]$CONDA/bin"
-    displayName: Add conda to PATH
+  - script: |
+      mkdir -p ~/miniforge3
+      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+      rm -rf  ~/miniforge3/miniforge.sh
+      ~/miniforge3/bin/conda init bash
+      ~/miniforge3/bin/conda init zsh
+      export CONDA=$(realpath ~/miniforge3/bin)
+      echo "##vso[task.prependpath]$CONDA"
+    displayName: Install conda
   - script: conda create --yes --quiet --name abyss_CI
     displayName: Create Anaconda environment
   - script: |
       source activate abyss_CI
-      conda install --yes -c conda-forge mamba python=3.9
       mamba install --yes -c conda-forge -c bioconda compilers=1.4.0 make boost-cpp sparsehash openmpi automake perl pandoc llvm-openmp btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
     displayName: Install dependencies
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,8 +81,8 @@ jobs:
       source activate abyss_CI
       ./autogen.sh
       ./configure
-      make -j12 distcheck
-    displayName: Compiling ABySS
+      make -j12 distcheck AM_CXXFLAGS=-Wno-error=unused-but-set-variable
+    displayName: Compiling ABySS with clang 16
 
 - job:
   displayName: mac_clang15
@@ -109,8 +109,8 @@ jobs:
       source activate abyss_CI
       ./autogen.sh
       ./configure
-      make -j12 distcheck
-    displayName: Compiling ABySS
+      make -j12 distcheck AM_CXXFLAGS=-Wno-error=unused-but-set-variable
+    displayName: Compiling ABySS with clang 15
 
 - job:
   displayName: mac_clang14
@@ -138,7 +138,7 @@ jobs:
       ./autogen.sh
       ./configure
       make -j12 distcheck
-    displayName: Compiling ABySS
+    displayName: Compiling ABySS with clang 14
 
 - job:
   displayName: mac_clang13
@@ -168,209 +168,178 @@ jobs:
       make -j12 distcheck
     displayName: Compiling ABySS with clang 13
 
-- job:
-  displayName: mac_clang12
+- job: linux_gcc12
   pool:
-    vmImage: 'macOS-latest'
+    vmImage: ubuntu-latest
   steps:
   - script: |
-      mkdir -p ~/miniforge3
-      curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-      bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-      rm -rf  ~/miniforge3/miniforge.sh
-      ~/miniforge3/bin/conda init bash
-      ~/miniforge3/bin/conda init zsh
-      export CONDA=$(realpath ~/miniforge3/bin)
-      echo "##vso[task.prependpath]$CONDA"
-    displayName: Install conda
+      sudo apt-get update -qq
+      sudo apt-get install -qq software-properties-common
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+      sudo apt-get update -qq
+      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+    displayName: Install common
+  - script: sudo apt-get install -qq gcc-12 g++-12
+    displayName: Install gcc-12
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+      tar xzf btllib-1.7.2.tar.gz
+      cd btllib-1.7.2
+      export CC=gcc-12
+      export CXX=g++-12
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-12 CXX=g++-12 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+      ./configure CC=gcc-12 CXX=g++-12 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+      make -j12 distcheck
+    displayName: Compiling ABySS with gcc-12
+
+
+- job: linux_gcc11
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - script: |
+      sudo apt-get update -qq
+      sudo apt-get install -qq software-properties-common
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+      sudo apt-get update -qq
+      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+    displayName: Install common
+  - script: sudo apt-get install -qq gcc-11 g++-11
+    displayName: Install gcc-11
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+      tar xzf btllib-1.7.2.tar.gz
+      cd btllib-1.7.2
+      export CC=gcc-11
+      export CXX=g++-11
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-11 CXX=g++-11 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+      ./configure CC=gcc-11 CXX=g++-11 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+      make -j12 distcheck
+    displayName: Compiling ABySS with gcc-11
+
+- job: linux_gcc10
+  pool:
+    vmImage: ubuntu-20.04
+  steps:
+  - script: |
+      sudo apt-get update -qq
+      sudo apt-get install -qq software-properties-common
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+      sudo apt-get update -qq
+      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+    displayName: Install common
+  - script: sudo apt-get install -qq gcc-10 g++-10
+    displayName: Install gcc-10
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+      tar xzf btllib-1.7.2.tar.gz
+      cd btllib-1.7.2
+      export CC=gcc-10
+      export CXX=g++-10
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-10 CXX=g++-10 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+      ./configure CC=gcc-10 CXX=g++-10 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+      make -j12 distcheck
+    displayName: Compiling ABySS with gcc-10
+  - script: |
+      curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+      sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+      sudo apt-get update
+      sudo apt-get install -y --no-install-recommends clang-format-8
+      sudo ln -sf clang-format-8 /usr/bin/clang-format
+    displayName: Install clang-format
+  - script: make clang-format
+    displayName: Run clang-format
+
+- job: linux_gcc9
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - script: |
+      sudo apt-get update -qq
+      sudo apt-get install -qq software-properties-common
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
+      sudo apt-get update -qq
+      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+    displayName: Install common
+  - script: sudo apt-get install -qq gcc-9 g++-9
+    displayName: Install gcc-9
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
+      tar xzf btllib-1.7.2.tar.gz
+      cd btllib-1.7.2
+      export CC=gcc-9
+      export CXX=g++-9
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-9 CXX=g++-9 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
+      ./configure CC=gcc-9 CXX=g++-9 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
+      make -j12 distcheck
+    displayName: Compiling ABySS with gcc-9
+
+- job: linux_gcc8
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - script: |
+      sudo apt-get update -qq
+      sudo apt-get install -qq software-properties-common
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal main universe security"
+      sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal-updates main universe restricted"
+      sudo apt-get update -qq
+      sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
+    displayName: Install common
+  - script: sudo apt-get install -qq gcc-8 g++-8
+    displayName: Install gcc-8
+  - script: |
+      wget https://github.com/bcgsc/btllib/releases/download/v1.6.0/btllib-1.6.0.tar.gz
+      tar xzf btllib-1.6.0.tar.gz
+      cd btllib-1.6.0
+      export CC=gcc-8
+      export CXX=g++-8
+      ./compile
+    displayName: Install btllib
+  - script: |
+      ./autogen.sh
+      export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-8 CXX=g++-8 --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install"
+      ./configure CC=gcc-8 CXX=g++-8 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install
+      make -j12 distcheck
+    displayName: Compiling ABySS with gcc-8
+
+- job:
+  displayName: linux_gcc-latest
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - script: echo "##vso[task.prependpath]$CONDA/bin"
+    displayName: Add conda to PATH
   - script: conda create --yes --quiet --name abyss_CI
     displayName: Create Anaconda environment
   - script: |
       source activate abyss_CI
-      conda install --yes -c conda-forge -c bioconda compilers=1.4.0 make boost-cpp sparsehash openmpi automake perl pandoc llvm-openmp btllib 'llvm-openmp<17.0.0' 'libcxx<17.0.0'
+      conda install --yes -c conda-forge mamba python=3.9
+      mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi util-linux perl btllib pandoc
     displayName: Install dependencies
   - script: |
       source activate abyss_CI
-      echo $CXXFLAGS
-      ls /Users/runner/miniforge3/envs/abyss_CI/include
       ./autogen.sh
       ./configure
-      make -j12 distcheck
-    displayName: Compiling ABySS with clang 12
-
-
-# - job: linux_gcc12
-#   pool:
-#     vmImage: ubuntu-latest
-#   steps:
-#   - script: |
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq software-properties-common
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-#     displayName: Install common
-#   - script: sudo apt-get install -qq gcc-12 g++-12
-#     displayName: Install gcc-12
-#   - script: |
-#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-#       tar xzf btllib-1.7.2.tar.gz
-#       cd btllib-1.7.2
-#       export CC=gcc-12
-#       export CXX=g++-12
-#       ./compile
-#     displayName: Install btllib
-#   - script: |
-#       ./autogen.sh
-#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-12 CXX=g++-12 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-#       ./configure CC=gcc-12 CXX=g++-12 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-#       make -j12 distcheck
-#     displayName: Compiling ABySS with gcc-12
-
-
-# - job: linux_gcc11
-#   pool:
-#     vmImage: ubuntu-latest
-#   steps:
-#   - script: |
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq software-properties-common
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-#     displayName: Install common
-#   - script: sudo apt-get install -qq gcc-11 g++-11
-#     displayName: Install gcc-11
-#   - script: |
-#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-#       tar xzf btllib-1.7.2.tar.gz
-#       cd btllib-1.7.2
-#       export CC=gcc-11
-#       export CXX=g++-11
-#       ./compile
-#     displayName: Install btllib
-#   - script: |
-#       ./autogen.sh
-#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-11 CXX=g++-11 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-#       ./configure CC=gcc-11 CXX=g++-11 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-#       make -j12 distcheck
-#     displayName: Compiling ABySS with gcc-11
-
-# - job: linux_gcc10
-#   pool:
-#     vmImage: ubuntu-20.04
-#   steps:
-#   - script: |
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq software-properties-common
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-#     displayName: Install common
-#   - script: sudo apt-get install -qq gcc-10 g++-10
-#     displayName: Install gcc-10
-#   - script: |
-#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-#       tar xzf btllib-1.7.2.tar.gz
-#       cd btllib-1.7.2
-#       export CC=gcc-10
-#       export CXX=g++-10
-#       ./compile
-#     displayName: Install btllib
-#   - script: |
-#       ./autogen.sh
-#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-10 CXX=g++-10 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-#       ./configure CC=gcc-10 CXX=g++-10 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-#       make -j12 distcheck
-#     displayName: Compiling ABySS with gcc-10
-#   - script: |
-#       curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-#       sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
-#       sudo apt-get update
-#       sudo apt-get install -y --no-install-recommends clang-format-8
-#       sudo ln -sf clang-format-8 /usr/bin/clang-format
-#     displayName: Install clang-format
-#   - script: make clang-format
-#     displayName: Run clang-format
-
-# - job: linux_gcc9
-#   pool:
-#     vmImage: ubuntu-latest
-#   steps:
-#   - script: |
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq software-properties-common
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic main universe security"
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu bionic-updates main universe restricted"
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-#     displayName: Install common
-#   - script: sudo apt-get install -qq gcc-9 g++-9
-#     displayName: Install gcc-9
-#   - script: |
-#       wget https://github.com/bcgsc/btllib/releases/download/v1.7.2/btllib-1.7.2.tar.gz
-#       tar xzf btllib-1.7.2.tar.gz
-#       cd btllib-1.7.2
-#       export CC=gcc-9
-#       export CXX=g++-9
-#       ./compile
-#     displayName: Install btllib
-#   - script: |
-#       ./autogen.sh
-#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-9 CXX=g++-9 --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install"
-#       ./configure CC=gcc-9 CXX=g++-9 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.7.2/install
-#       make -j12 distcheck
-#     displayName: Compiling ABySS with gcc-9
-
-# - job: linux_gcc8
-#   pool:
-#     vmImage: ubuntu-latest
-#   steps:
-#   - script: |
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq software-properties-common
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal main universe security"
-#       sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu focal-updates main universe restricted"
-#       sudo apt-get update -qq
-#       sudo apt-get install -qq autoconf automake gcc g++ libboost-dev libgtest-dev libopenmpi-dev libsparsehash-dev make pandoc
-#     displayName: Install common
-#   - script: sudo apt-get install -qq gcc-8 g++-8
-#     displayName: Install gcc-8
-#   - script: |
-#       wget https://github.com/bcgsc/btllib/releases/download/v1.6.0/btllib-1.6.0.tar.gz
-#       tar xzf btllib-1.6.0.tar.gz
-#       cd btllib-1.6.0
-#       export CC=gcc-8
-#       export CXX=g++-8
-#       ./compile
-#     displayName: Install btllib
-#   - script: |
-#       ./autogen.sh
-#       export DISTCHECK_CONFIGURE_FLAGS="CC=gcc-8 CXX=g++-8 --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install"
-#       ./configure CC=gcc-8 CXX=g++-8 --with-mpi=/usr/lib/openmpi --with-btllib=/home/vsts/work/1/s/btllib-1.6.0/install
-#       make -j12 distcheck
-#     displayName: Compiling ABySS with gcc-8
-
-# - job:
-#   displayName: linux_gcc-latest
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   steps:
-#   - script: echo "##vso[task.prependpath]$CONDA/bin"
-#     displayName: Add conda to PATH
-#   - script: conda create --yes --quiet --name abyss_CI
-#     displayName: Create Anaconda environment
-#   - script: |
-#       source activate abyss_CI
-#       conda install --yes -c conda-forge mamba python=3.9
-#       mamba install --yes -c conda-forge -c bioconda compilers make boost-cpp sparsehash openmpi util-linux perl btllib pandoc
-#     displayName: Install dependencies
-#   - script: |
-#       source activate abyss_CI
-#       ./autogen.sh
-#       ./configure
-#       make -j12 distcheck AM_CXXFLAGS=-Wall CXXFLAGS='-pthread'
-#     displayName: Compiling ABySS with gcc
+      make -j12 distcheck AM_CXXFLAGS=-Wall CXXFLAGS='-pthread'
+    displayName: Compiling ABySS with gcc


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit
* Added dedicated CI for clang 15, 16 ; removed old clang-12 